### PR TITLE
Issue #70: Improve locking for iatsrecurringcontributions API.

### DIFF
--- a/api/v3/Job/Iatsrecurringcontributions.php
+++ b/api/v3/Job/Iatsrecurringcontributions.php
@@ -32,6 +32,11 @@ function _civicrm_api3_job_iatsrecurringcontributions_spec(&$spec) {
 function civicrm_api3_job_iatsrecurringcontributions($params) {
   // running this job in parallell could generate bad duplicate contributions
   $lock = new CRM_Core_Lock('civimail.job.IatsRecurringContributions');
+
+  if (! $lock->acquire()) {
+    return civicrm_api3_create_success(ts('Failed to acquire lock. No contribution records were processed.'));
+  }
+
   // TODO: what kind of extra security do we want or need here to prevent it from being triggered inappropriately? Or does it matter?
 
   // the next scheduled contribution date field name is civicrm version dependent


### PR DESCRIPTION
The acquire() function must be called for CRM_Core_Lock to work. It will try to acquire within 3 seconds (default timeout), and fail if it couldn't lock.

I tested running the API call twice at the exact same time (running it from the command line with "drush cvapi Job.execute & [up, enter]"), and was able to process transactions twice on the same day. This patch seems to solve the issue.