### PR TITLE
js/contribute_form_search.js: Prevent JS errors on empty crmLoad.

### DIFF
--- a/js/contribute_form_search.js
+++ b/js/contribute_form_search.js
@@ -11,6 +11,7 @@ cj(function ($) {
   $('#crm-main-content-wrapper').crmSnippet().on('crmLoad', function(e, data) {
     var backofficeLinks = (typeof CRM.vars.iatspayments != 'undefined') ? CRM.vars.iatspayments.backofficeLinks : CRM.iatspayments.backofficeLinks;
     if (0 < backofficeLinks.length 
+        && typeof data != 'undefined'
         && data.title == 'Contributions'
         && 0 == $('form.CRM_Contribute_Form_Search #help .acheft-backend-link').length
         && 0 < $('form.CRM_Contribute_Form_Search #help').filter(':visible').length


### PR DESCRIPTION
I ran into an obscure bug that only happens with

- Chrome (not Firefox)
- CiviCRM 4.7
- iATS extension enabled

To reproduce the bug:

- go to a contact record
- add a new relationship

Saving the relationship will trigger a partial form reload, but it will spin forever because of a javascript error:

    Uncaught TypeError: Cannot read property 'title' of undefined"

To be honest, the trigger of a crmLoad with undefined data is probably a bug in itself, but there's a lot happening when updating relationships, so I figured it was safe in any case to add the proposed check?