### PR TITLE
Public future recurring start

### DIFF
--- a/CRM/iATS/Form/IatsSettings.php
+++ b/CRM/iATS/Form/IatsSettings.php
@@ -61,6 +61,14 @@ class CRM_iATS_Form_IatsSettings extends CRM_Core_Form {
       ts('Enable self-service updates to recurring contribution Contact Billing Info.')
     );
 
+    $this->add(
+    // Field type.
+      'checkbox',
+    // Field name.
+      'enable_public_future_recurring_start',
+      ts('Enable public selection of future recurring start dates.')
+    );
+
     $days = array('-1' => 'disabled');
     for ($i = 1; $i <= 28; $i++) {
       $days["$i"] = "$i";

--- a/js/recur_start.js
+++ b/js/recur_start.js
@@ -1,0 +1,11 @@
+/* custom js for uk dd */
+/*jslint indent: 2 */
+/*global CRM, ts */
+
+function iatsRecurStartRefresh() {
+  cj(function ($) {
+    'use strict';
+     console.log($('#iats-recurring-start-date'));
+     $('.is_recur-section').after($('#iats-recurring-start-date'));
+  });
+}

--- a/templates/CRM/iATS/BillingBlockRecurringExtra.tpl
+++ b/templates/CRM/iATS/BillingBlockRecurringExtra.tpl
@@ -1,0 +1,10 @@
+<div id="iats-recurring-start-date">
+  <div class="crm-section recurring-start-date">
+    <div class="label">{$form.receive_date.label}</div>
+    <div class="content">{$form.receive_date.html}
+      <div class="description">{ts domain='com.iatspayments.civicrm'}You may select a later start date if you wish.{/ts}</div>
+    </div>
+    <div class="clear"></div>
+  </div>
+</div>
+{literal}<script type="text/javascript">cj(function ($) { iatsRecurStartRefresh();});</script>{/literal}


### PR DESCRIPTION
This PR provides an option to enable user-chosen start dates for recurring contributions.
The user-facing options are either any day in the next 31 days, or a selection if the administrator has restricted recurring contributions to specific days of the month.