### PR TITLE
Implements hook_civicrm_check() for the SOAP check, fixes #154.

### DIFF
--- a/iats.php
+++ b/iats.php
@@ -161,6 +161,21 @@ function iats_civicrm_managed(&$entities) {
 }
 
 /**
+ * Implements hook_civicrm_check().
+ */
+function iats_civicrm_check(&$messages) {
+  if (!class_exists('SoapClient')) {
+    $messages[] = new CRM_Utils_Check_Message(
+      'iats_soap',
+      ts('The SOAP extension for PHP %1 is not installed on this server, but is required for this extension.', array(1 => phpversion())),
+      ts('iATS Payments Installation'),
+      \Psr\Log\LogLevel::CRITICAL,
+      'fa-flag'
+    );
+  }
+}
+
+/**
  * Utility function to get domain info.
  *
  * Get values from the civicrm_domain table, or a domain setting.


### PR DESCRIPTION
After migrating civicrm.org to another server, we had not realized that the SOAP extension was missing (now added to our [Ansible playbooks](https://github.com/civicrm/civicrm-infra/commit/31aa8ae3dc9d13230a865e6c668f316332e9743c)). This PR adds a `hook_civicrm_check()` to warn about a missing SOAP extension (connected to our icinga2 monitoring).

I also added the `phpversion()` in the error message, to help those who may have different PHP versions on CLI (ex: on cpanel?).