### PR TITLE
Added credit unions in autocomplete when typing in bank number.

### DIFF
--- a/js/dd_cad.js
+++ b/js/dd_cad.js
@@ -35,6 +35,13 @@ function iatsACHEFTca() {
         case '016': $('#bank_name').val('HSBC Canada'); break;
         case '030': $('#bank_name').val('Canadian Western Bank'); break;
         case '326': $('#bank_name').val('President\'s Choice Financial'); break;
+
+        case '839': // Credit Union Heritage (Nova Scotia)
+        case '879': // Credit Union Central of Manitoba
+        case '889': // Credit Union Central of Saskatchewan
+        case '899': // Credit Union Central Alberta
+          $('#bank_name').val('Credit Union'); break;
+        
         default: $('#bank_name').val(''); break;
       }
       iatsSetBankIdenficationNumber();


### PR DESCRIPTION
Many of our donors use Credit Union bank to do EFT donations to us, so I added those bank number into the EFT form auto-completion to fill out bank name when user enters the corresponding bank numbers.

839: Credit Union Heritage (Nova Scotia)
879: Credit Union Central of Manitoba
889: Credit Union Central of Saskatchewan
899: Credit Union Central Alberta

All of the above will auto-enter "Credit Union" in the bank name text box.