### PR TITLE
Update code formatting for half-dozen API files

### DIFF
--- a/api/v3/IatsPayments/GetJournal.php
+++ b/api/v3/IatsPayments/GetJournal.php
@@ -9,8 +9,6 @@
  *
  * @param array $params
  *
- * @return array
- *
  * Get entries from iATSPayments in the journal table
  */
 function _civicrm_api3_iats_payments_get_journal_spec(&$params) {
@@ -63,7 +61,7 @@ function civicrm_api3_iats_payments_get_journal($params) {
     'inv' => 'String',
   );
   $i = 0;
-  foreach($params as $key => $value) {
+  foreach ($params as $key => $value) {
     if (isset($select_params[$key])) {
       $i++;
       if (is_string($value)) {
@@ -71,7 +69,7 @@ function civicrm_api3_iats_payments_get_journal($params) {
         $args[$i] = array($value, $select_params[$key]);
       }
       elseif (is_array($value)) {
-        foreach(array_keys($value) as $sql) {
+        foreach (array_keys($value) as $sql) {
           $select .= " AND ($key %$i)";
           $args[$i] = array($sql, 'String');
         }
@@ -80,7 +78,7 @@ function civicrm_api3_iats_payments_get_journal($params) {
   }
   $limit = 25;
   if (isset($params['options']['limit'])) {
-    $limit =  (integer) $params['options']['limit'];
+    $limit = (integer) $params['options']['limit'];
   }
   if ($limit > 0) {
     $i++;
@@ -101,18 +99,17 @@ function civicrm_api3_iats_payments_get_journal($params) {
       /* We index in the transaction_id */
       $record = array();
       foreach (get_object_vars($dao) as $key => $value) {
-        if ('N' != $key && (0 !== strpos($key,'_'))) {
+        if ('N' != $key && (0 !== strpos($key, '_'))) {
           $record[$key] = $value;
         }
       }
       $key = $dao->tnid;
-      $values[$key] =  $record;
+      $values[$key] = $record;
     }
   }
   catch (Exception $e) {
-    CRM_Core_Error::debug_var('params',$params);
+    CRM_Core_Error::debug_var('params', $params);
     // throw API_Exception('iATS Payments journalling failed: '. $e->getMessage());
   }
   return civicrm_api3_create_success($values);
 }
-

--- a/api/v3/IatsPayments/Journal.php
+++ b/api/v3/IatsPayments/Journal.php
@@ -9,8 +9,6 @@
  *
  * @param array $params
  *
- * @return array
- *
  * Record an entry from iATSPayments into the journal table
  */
 function _civicrm_api3_iats_payments_journal_spec(&$params) {
@@ -36,13 +34,13 @@ function civicrm_api3_iats_payments_journal($params) {
   //return civicrm_api3_create_success(TRUE, array('test' => TRUE));
   try {
     $data = $params['data'];
-    $dtm = date('YmdHis',$params['receive_date']);
+    $dtm = date('YmdHis', $params['receive_date']);
     $defaults = array(
-      'Client Code' => '', 
+      'Client Code' => '',
       'Method of Payment' => '',
-      'Comment' => ''
+      'Comment' => '',
     );
-    foreach($defaults as $key => $default) {
+    foreach ($defaults as $key => $default) {
       $data[$key] = empty($data[$key]) ? $default : $data[$key];
     }
     // There are unique keys on tnid (transaction) and iats_id (journal)
@@ -67,13 +65,12 @@ function civicrm_api3_iats_payments_journal($params) {
       10 => array($data['Comment'], 'String'),
       11 => array($params['status_id'], 'Integer'),
     );
-    $result = CRM_Core_DAO::executeQuery($sql_action ." civicrm_iats_journal
+    $result = CRM_Core_DAO::executeQuery($sql_action . " civicrm_iats_journal
         (tnid, iats_id, dtm, agt, cstc, inv, amt, rst, tntyp, cm, status_id) VALUES (%1, $iats_journal_id, %3, %4, %5, %6, %7, %8, %9, %10, %11)", $query_params);
   }
   catch (Exception $e) {
-    CRM_Core_Error::debug_var('params',$params);
-    // throw CiviCRM_API3_Exception('iATS Payments journalling failed: '. $e->getMessage());
+    CRM_Core_Error::debug_var('params', $params);
+    // throw CiviCRM_API3_Exception('iATS Payments journalling failed: ' . $e->getMessage());
   }
   return civicrm_api3_create_success();
 }
-

--- a/api/v3/Job/Iatsrecurringcontributions.php
+++ b/api/v3/Job/Iatsrecurringcontributions.php
@@ -275,7 +275,7 @@ function civicrm_api3_job_iatsrecurringcontributions($params) {
       $contribution['financial_type_id'] = $dao->financial_type_id;
     }
     // if we have a created a pending contribution record due to a future start time, then recycle that CiviCRM contribution record now.
-    // Note that the date and amount both could have changed. 
+    // Note that the date and amount both could have changed.
     // The key is to only match if we find a single pending contribution, with a NULL transaction id, for this recurring schedule.
     // We'll need to pay attention later that we may or may not already have a contribution id.
     try {
@@ -331,7 +331,7 @@ function civicrm_api3_job_iatsrecurringcontributions($params) {
       }
       // So far so, good ... now create the pending contribution, and save its id
       // and then try to get the money, and do one of:
-      // update the contribution to failed, leave as pending for server failure, complete the transaction, 
+      // update the contribution to failed, leave as pending for server failure, complete the transaction,
       // or update a pending ach/eft with it's transaction id.
       $result = _iats_process_contribution_payment($contribution, $options, $original_contribution_id);
       if ($email_failure_report && !empty($contribution['iats_reject_code'])) {

--- a/api/v3/Job/Iatsreport.mgd.php
+++ b/api/v3/Job/Iatsreport.mgd.php
@@ -3,13 +3,13 @@
 // The record will be automatically inserted, updated, or deleted from the
 // database as appropriate. For more details, see "hook_civicrm_managed" at:
 // http://wiki.civicrm.org/confluence/display/CRMDOC42/Hook+Reference
-return array (
+return array(
   0 =>
-  array (
+  array(
     'name' => 'Cron:Job.Iatsreport',
     'entity' => 'Job',
     'params' =>
-    array (
+    array(
       'version' => 3,
       'name' => 'iATS Payments Get Transaction Journal',
       'description' => 'Call into iATS to get transaction journals (for auditing and verifying).',
@@ -18,6 +18,6 @@ return array (
       'api_action' => 'iatsreport',
       'parameters' => '',
     ),
-    'update' => 'never'
+    'update' => 'never',
   ),
 );

--- a/api/v3/Job/Iatsreport.php
+++ b/api/v3/Job/Iatsreport.php
@@ -2,8 +2,8 @@
 
 /**
  * Job.IatsReport API specification (optional)
- * 
- * Pull in the iATS transaction journal and save it in the corresponding table 
+ *
+ * Pull in the iATS transaction journal and save it in the corresponding table
  * for local access for easier verification, auditing and reporting.
  *
  * @param array $spec description of fields supported by this API call
@@ -18,12 +18,6 @@ function _civicrm_api3_job_iatsreport_spec(&$spec) {
 /**
  * Job.IatsReport API
  *
- * @param array $params
- * @return array API result descriptor
- * @see civicrm_api3_create_success
- * @see civicrm_api3_create_error
- * @throws API_Exception
-
  * Fetch all recent transactions from iATS for the purposes of auditing (in separate jobs).
  * This addresses multiple needs:
  * 1. Verify incomplete ACH/EFT contributions.
@@ -32,6 +26,11 @@ function _civicrm_api3_job_iatsreport_spec(&$spec) {
  * 4. Input one-time contributions that did not go through CiviCRM
  * 5. Audit for remote changes in iATS.
  *
+ * @param array $params
+ * @return array API result descriptor
+ * @see civicrm_api3_create_success
+ * @see civicrm_api3_create_error
+ * @throws API_Exception
  */
 function civicrm_api3_job_iatsreport($params) {
 
@@ -46,13 +45,13 @@ function civicrm_api3_job_iatsreport($params) {
     ));
   }
   catch (CiviCRM_API3_Exception $e) {
-    throw new API_Exception('Unexpected error getting payment processors: ' . $e->getMessage()); //  . "\n" . $e->getTraceAsString()); 
+    throw new API_Exception('Unexpected error getting payment processors: ' . $e->getMessage()); //  . "\n" . $e->getTraceAsString());
   }
   if (empty($result['values'])) {
     return;
   }
   $payment_processors = array();
-  foreach($result['values'] as $payment_processor) {
+  foreach ($result['values'] as $payment_processor) {
     $user_name = $payment_processor['user_name'];
     $type = $payment_processor['payment_type']; // 1 for cc, 2 for ach/eft
     $id = $payment_processor['id'];
@@ -69,25 +68,25 @@ function civicrm_api3_job_iatsreport($params) {
   $iats_settings = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_settings');
   // I also use the setttings to keep track of the last time I imported journal data from iATS.
   $iats_journal = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_journal');
-  foreach(array('quick', 'recur', 'series') as $setting) {
-    $import[$setting] = empty($iats_settings['import_'.$setting]) ? 0 : 1;
+  foreach (array('quick', 'recur', 'series') as $setting) {
+    $import[$setting] = empty($iats_settings['import_' . $setting]) ? 0 : 1;
   }
-  require_once("CRM/iATS/iATSService.php");
+  require_once "CRM/iATS/iATSService.php";
   // an array of types => methods => payment status of the records retrieved
   $process_methods = array(
-    1 => array('cc_journal_csv' => 1,'cc_payment_box_journal_csv' => 1, 'cc_payment_box_reject_csv' => 4),
-    2 => array('acheft_journal_csv' => 1, 'acheft_payment_box_journal_csv' => 1, 'acheft_payment_box_reject_csv' => 4)
+    1 => array('cc_journal_csv' => 1, 'cc_payment_box_journal_csv' => 1, 'cc_payment_box_reject_csv' => 4),
+    2 => array('acheft_journal_csv' => 1, 'acheft_payment_box_journal_csv' => 1, 'acheft_payment_box_reject_csv' => 4),
   );
   /* initialize some values so I can report at the end */
   // count the number of records from each iats account analysed, and the number of each kind found ('action')
   $processed = array();
   // save all my api result error messages as well
   $error_log = array();
-  foreach($payment_processors as $user_name => $payment_processors_per_user) {
+  foreach ($payment_processors as $user_name => $payment_processors_per_user) {
     $processed[$user_name] = array();
     foreach ($payment_processors_per_user as $type => $payment_processors_per_user_type) {
       $processed[$user_name][$type] = array();
-      // we might have multiple payment processors by type e.g. SWIPE or separate codes for 
+      // we might have multiple payment processors by type e.g. SWIPE or separate codes for
       // one-time and recurring contributions, I only want to process once per user_name + type
       $payment_processor = reset($payment_processors_per_user_type);
       $process_methods_per_type = $process_methods[$type];
@@ -95,7 +94,7 @@ function civicrm_api3_job_iatsreport($params) {
       /* the is_test below should always be 0, but I'm leaving it in, in case eventually we want to be verifying tests */
       $credentials = iATS_Service_Request::credentials($payment_processor['id'], $payment_processor['is_test']);
 
-      foreach($process_methods_per_type as $method => $payment_status_id) {
+      foreach ($process_methods_per_type as $method => $payment_status_id) {
         // initialize my counts
         $processed[$user_name][$type][$method] = 0;
         // watchdog('civicrm_iatspayments_com', 'pp: <pre>!pp</pre>', array('!pp' => print_r($payment_processor,TRUE)), WATCHDOG_NOTICE);
@@ -105,20 +104,22 @@ function civicrm_api3_job_iatsreport($params) {
         $iats = new iATS_Service_Request($iats_service_params);
         // For some methods, I only want to check once per day.
         $skip_method = FALSE;
-        $journal_setting_key = 'last_update_'.$method;
-        switch($method) {
+        $journal_setting_key = 'last_update_' . $method;
+        switch ($method) {
           case 'acheft_journal_csv': // special case to get today's transactions, so we're as real-time as we can be
-          case 'cc_journal_csv': 
+          case 'cc_journal_csv':
             $request = array(
-              'date' => date('Y-m-d').'T23:59:59+00:00',
+              'date' => date('Y-m-d') . 'T23:59:59+00:00',
               'customerIPAddress' => (function_exists('ip_address') ? ip_address() : $_SERVER['REMOTE_ADDR']),
             );
             break;
-          default: // box journals (approvals and rejections) only go up to the end of yesterday
+
+          default:
+            // box journals (approvals and rejections) only go up to the end of yesterday
             $request = array(
               'startIndex' => 0,
               'endIndex' => 1000,
-              'toDate' => date('Y-m-d',strtotime('-1 day')).'T23:59:59+00:00',
+              'toDate' => date('Y-m-d', strtotime('-1 day')) . 'T23:59:59+00:00',
               'customerIPAddress' => (function_exists('ip_address') ? ip_address() : $_SERVER['REMOTE_ADDR']),
             );
             // Calculate how far back I want to go, default 2 days ago.
@@ -126,50 +127,54 @@ function civicrm_api3_job_iatsreport($params) {
             // Check when I last downloaded this box journal
             if (!empty($iats_journal[$journal_setting_key])) {
               // If I've already done this today, don't do it again.
-              if (0 === strpos($iats_journal[$journal_setting_key],date('Y-m-d'))) {
+              if (0 === strpos($iats_journal[$journal_setting_key], date('Y-m-d'))) {
                 $skip_method = TRUE;
               }
-              else { // Make sure I fill in any gaps if this cron hasn't run for a while, but no more than a month
-                $fromDate = min(strtotime($iats_journal[$journal_setting_key]),strtotime('-2 days'));
-                $fromDate = max($fromDate,strtotime('-30 days'));
+              else {
+                // Make sure I fill in any gaps if this cron hasn't run for a while, but no more than a month
+                $fromDate = min(strtotime($iats_journal[$journal_setting_key]), strtotime('-2 days'));
+                $fromDate = max($fromDate, strtotime('-30 days'));
               }
             }
-            else { // If I've cleared the settings, then go back a month of data.
+            else {
+              // If I've cleared the settings, then go back a month of data.
               $fromDate = strtotime('-30 days');
             }
             // reset the request fromDate, from the beginning of fromDate's day.
-            $request['fromDate'] = date('Y-m-d',$fromDate).'T00:00:00+00:00';
+            $request['fromDate'] = date('Y-m-d', $fromDate) . 'T00:00:00+00:00';
             break;
         }
         if (!$skip_method) {
           $iats_journal[$journal_setting_key] = date('Y-m-d H:i:s');
           // make the soap request, should return a csv file
-          $response = $iats->request($credentials,$request);
+          $response = $iats->request($credentials, $request);
           // use my iats object to parse the result into an array of transaction ojects
           $transactions = $iats->getCSV($response, $method);
           // for the acheft journal, I also pull the previous 4 days and append, a bit of a hack.
           if ('acheft_journal_csv' == $method) {
             for ($days_before = -1; $days_before > -5; $days_before--) {
-              $request['date'] = date('Y-m-d', strtotime($days_before.' day')) . 'T23:59:59+00:00';
+              $request['date'] = date('Y-m-d', strtotime($days_before . ' day')) . 'T23:59:59+00:00';
               $response = $iats->request($credentials, $request);
               $transactions = array_merge($transactions, $iats->getCSV($response, $method));
             }
           }
           // CRM_Core_Error::debug_var($method, $transactions);
-          foreach($transactions as $transaction) {
+          foreach ($transactions as $transaction) {
             try {
               $t = get_object_vars($transaction);
               $t['status_id'] = $payment_status_id;
               // A few more hacks for the one day journals
-              switch($method) {
-                case 'acheft_journal_csv': 
+              switch ($method) {
+                case 'acheft_journal_csv':
                   $t['data']['Method of Payment'] = 'ACHEFT';
                   $t['data']['Client Code'] = $credentials['agentCode'];
                   break;
-                case 'cc_journal_csv': 
+
+                case 'cc_journal_csv':
                   $t['data']['Method of Payment'] = $t['data']['CCType'];
                   $t['data']['Client Code'] = $credentials['agentCode'];
                   break;
+
               }
               civicrm_api3('IatsPayments', 'journal', $t);
               $processed[$user_name][$type][$method]++;
@@ -185,18 +190,18 @@ function civicrm_api3_job_iatsreport($params) {
   CRM_Core_BAO_Setting::setItem($iats_journal, 'iATS Payments Extension', 'iats_journal');
   // watchdog('civicrm_iatspayments_com', 'found: <pre>!found</pre>', array('!found' => print_r($processed,TRUE)), WATCHDOG_NOTICE);
   $message = '';
-  foreach($processed as $user_name => $p) {
+  foreach ($processed as $user_name => $p) {
     foreach ($p as $type => $ps) {
       $prefix = ($type == 1) ? 'cc' : 'acheft';
-      $results =
-        array(
+      $results
+        = array(
           1 => $user_name,
           2 => $prefix,
-          3 => $ps[$prefix.'_journal_csv'],
-          4 => $ps[$prefix.'_payment_box_journal_csv'],
-          5 => $ps[$prefix.'_payment_box_reject_csv'],
+          3 => $ps[$prefix . '_journal_csv'],
+          4 => $ps[$prefix . '_payment_box_journal_csv'],
+          5 => $ps[$prefix . '_payment_box_reject_csv'],
         );
-      $message .= '<br />'. ts('For account %1, type %2, processed %3 approvals from the one-day journals, and %4 approval and %5 rejection records from previous days using the box journals.', $results);
+      $message .= '<br />' . ts('For account %1, type %2, processed %3 approvals from the one-day journals, and %4 approval and %5 rejection records from previous days using the box journals.', $results);
     }
   }
   if (count($error_log) > 0) {

--- a/api/v3/Job/Iatsverify.php
+++ b/api/v3/Job/Iatsverify.php
@@ -51,6 +51,12 @@ function _civicrm_api3_job_iatsverify_spec(&$spec) {
 /**
  * Job.IatsVerify API.
  *
+ * Look up all incomplete or pending (status = 2) contributions and see if they've been received approved or rejected payments
+ * at iATS, looked up via the Journal
+ * Update the corresponding recurring contribution record to status = 1 (or 4)
+ * This works for both the initial contribution and subsequent contributions of recurring contributions, as well as one offs.
+ * TODO: what kind of alerts should be provided if it fails?
+ *
  * @param array $params
  *
  * @return array API result descriptor
@@ -59,12 +65,6 @@ function _civicrm_api3_job_iatsverify_spec(&$spec) {
  * @see civicrm_api3_create_error
  *
  * @throws API_Exception
- *  * Look up all incomplete or pending (status = 2) contributions and see if they've been received approved or rejected payments 
- * at iATS, looked up via the Journal
- * Update the corresponding recurring contribution record to status = 1 (or 4)
- * This works for both the initial contribution and subsequent contributions of recurring contributions, as well as one offs.
- * TODO: what kind of alerts should be provided if it fails?
- *
  */
 function civicrm_api3_job_iatsverify($params) {
 
@@ -80,7 +80,6 @@ function civicrm_api3_job_iatsverify($params) {
   $processed = array(1 => 0, 4 => 0);
   // Save all my api error result messages.
   $error_log = array();
-  //
   $select_params = array(
     'sequential' => 1,
     'receive_date' => array('>' => "now - $verify_days day"),
@@ -146,7 +145,7 @@ function civicrm_api3_job_iatsverify($params) {
                 }
                 catch (CiviCRM_API3_Exception $e) {
                   $is_email_receipt = 0;
-                  $error_log[] = $e->getMessage() ."\n";
+                  $error_log[] = $e->getMessage() . "\n";
                 }
               }
               $complete['is_email_receipt'] = $is_email_receipt;
@@ -155,19 +154,19 @@ function civicrm_api3_job_iatsverify($params) {
               $contributionResult = civicrm_api3('contribution', 'completetransaction', $complete);
             }
             catch (CiviCRM_API3_Exception $e) {
-              $error_log[] = 'Failed to complete transaction: '. $e->getMessage() ."\n";
+              $error_log[] = 'Failed to complete transaction: ' . $e->getMessage() . "\n";
             }
 
             // Restore source field and trxn_id that completetransaction overwrites
             civicrm_api3('contribution', 'create', array(
-              'id' => $contribution['id'], 
+              'id' => $contribution['id'],
               'source' => $contribution['source'],
-              'trxn_id' => $trxn_id
+              'trxn_id' => $trxn_id,
             ));
           case 4: // failed, just update the contribution status.
             civicrm_api3('Contribution', 'create', array(
               'id' => $contribution['id'],
-              'contribution_status_id' => $contribution_status_id
+              'contribution_status_id' => $contribution_status_id,
             ));
         }
         // Always log these requests in my cutom civicrm table for auditing type purposes
@@ -192,14 +191,14 @@ function civicrm_api3_job_iatsverify($params) {
     }
   }
   catch (CiviCRM_API3_Exception $e) {
-    $error_log[] = $e->getMessage() ."\n";
+    $error_log[] = $e->getMessage() . "\n";
   }
   $message .= '<br />' . ts('Completed with %1 errors.',
     array(
       1 => count($error_log),
     )
   );
-  $message .= '<br />' . ts('Processed %1 approvals and %2 rejection records from the previous ' . IATS_VERIFY_DAYS . ' days.', 
+  $message .= '<br />' . ts('Processed %1 approvals and %2 rejection records from the previous ' . IATS_VERIFY_DAYS . ' days.',
     array(
       1 => $processed[1],
       2 => $processed[4],


### PR DESCRIPTION
According to https://docs.civicrm.org/dev/en/latest/extensions/lifecycle/#review-criteria, official extensions should follow the same code-formatting as core.

You can get a general report on code-style compliance by running:

```
cd com.iatspayments.civicrm
find -name '*php' | civilint -
``` 

I was a bit impatient and started this process as follows -- this command sets up an interactive review for all your PHP files. (The command will display issues for file `#1`; then you can edit in another window; then re-evaluate file `#1`; and eventually move on to file `#2`, file `#3`, etc.)

```
cd com.iatspayments.civicrm
eval $( find -name '*php' | xargs echo phpcs-civi -a )
```

The process is amenable to divide-and-conquer (e.g. different people tackling different files).

You can alternatively look into using an IDE or `phpcbf`/`phpcbf-civi` to reformat source-code. (Those tools are fast and fix most issues -- although they takes more setup and may have a few wonky edge-cases.) Still, it's good to do a couple files with `phpcs-civi -a` as a way to quickly learn the style guidelines.