### PR TITLE
WIP: Fix ACH javascript race condition - ReferenceError: iatsACHEFTRefresh is not defined

### DIFF
--- a/templates/CRM/iATS/BillingBlockDirectDebitExtra_USD.tpl
+++ b/templates/CRM/iATS/BillingBlockDirectDebitExtra_USD.tpl
@@ -2,8 +2,6 @@
  Extra fields for iats direct debit, template for USD
 *}
 
-<script type="text/javascript" src="{crmResURL ext=com.iatspayments.civicrm file=js/dd_acheft.js}"></script>
-
 <div id="iats-direct-debit-extra">
   <div class="crm-section usd-instructions-section">
     <div class="label"><em>{ts domain='com.iatspayments.civicrm'}You can find your Bank Routing Number and Bank Account number by inspecting a check.{/ts}</em></div>
@@ -16,9 +14,14 @@
     <div class="clear"></div>
   </div>
 </div>
-{literal}<script type="text/javascript">
+{literal}
+<script type="text/javascript">
   cj(function ($) {
-    iatsACHEFTRefresh();
+    // iatsACHEFTRefresh
+    if ($('#iats-direct-debit-extra').length > 0) {
+      // move my custom fields up where they belong 
+      $('.direct_debit_info-section').prepend($('#iats-direct-debit-extra'));
+    }
   });
 </script>
 {/literal}


### PR DESCRIPTION
On one site, we encountered this error message in the browser console:

```
ReferenceError: iatsACHEFTRefresh is not defined
```

It was caused by an odd race condition, where I suspect that the `js/dd_acheft.js` file is taking too long to load. There is no way for the code to know whether the JS file has finished loading or not. We only encountered this on one site, and I have trouble explaining why, but I think that the javascript for ACH need a bit of tidying up.

This PR is not good, since it creates code duplication if we did the same thing in `templates/CRM/iATS/BillingBlockDirectDebitExtra_CAD.tpl`, but just to explain the issue..

A more proper solution might be to place all the iATS JS code in one common file, and load that file in `buildForm` for relevant forms.

Has anyone encountered this?