### PR TITLE
Always log soap faults to the CiviCRM error log

### DIFF
--- a/CRM/iATS/iATSService.php
+++ b/CRM/iATS/iATSService.php
@@ -224,7 +224,7 @@ class iATS_Service_Request {
       CRM_Core_Error::debug_var('SoapFault Exception', $exception);
       CRM_Core_Error::debug_var('SoapFault Code',$exception->faultcode);
       CRM_Core_Error::debug_var('SoapFault String',$exception->faultstring);
-      if (!empty($this->options['debug'])) {
+      if (!empty($this->options['debug']) && !empty($soapClient)) {
         $response_log = "\n HEADER:\n";
         $response_log .= $soapClient->__getLastResponseHeaders();
         $response_log .= "\n BODY:\n";

--- a/CRM/iATS/iATSService.php
+++ b/CRM/iATS/iATSService.php
@@ -220,8 +220,11 @@ class iATS_Service_Request {
       }
     }
     catch (SoapFault $exception) {
+      // always log soap faults to the CiviCRM error log
+      CRM_Core_Error::debug_var('SoapFault Exception', $exception);
+      CRM_Core_Error::debug_var('SoapFault Code',$exception->faultcode);
+      CRM_Core_Error::debug_var('SoapFault String',$exception->faultstring);
       if (!empty($this->options['debug'])) {
-        CRM_Core_Error::debug_var('SoapFault Exception', $exception);
         $response_log = "\n HEADER:\n";
         $response_log .= $soapClient->__getLastResponseHeaders();
         $response_log .= "\n BODY:\n";


### PR DESCRIPTION
As per issue #269 