### PR TITLE
Update tests to support phpunit 6

### DIFF
--- a/tests/phpunit/CRM/Iats/BaseTestClass.php
+++ b/tests/phpunit/CRM/Iats/BaseTestClass.php
@@ -16,7 +16,7 @@ use Civi\Test\TransactionalInterface;
  *       a. Do all that using setupHeadless() and Civi\Test.
  *       b. Disable TransactionalInterface, and handle all setup/teardown yourself.
  */
-abstract class BaseTestClass extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+abstract class BaseTestClass extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
   //class BaseTestClass extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface {
 
   /**


### PR DESCRIPTION
We need to get CiviCRM CI updated to support later php 7.3 - which will mean any tests that don't run on later versions will break - this is the main required change