### PR TITLE
Update Settings functions to use standard non deprecated Civi::settin…

### DIFF
--- a/CRM/Iats/Form/Settings.php
+++ b/CRM/Iats/Form/Settings.php
@@ -109,7 +109,7 @@ class CRM_Iats_Form_Settings extends CRM_Core_Form {
       ),
     ));
 
-    $result = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_settings');
+    $result = Civi::settings()->get('iats_settings');
     $defaults = (empty($result)) ? array() : $result;
     if (empty($defaults['recurring_failure_threshhold'])) {
       $defaults['recurring_failure_threshhold'] = 3;
@@ -139,7 +139,7 @@ class CRM_Iats_Form_Settings extends CRM_Core_Form {
         unset($values[$key]);
       }
     }
-    CRM_Core_BAO_Setting::setItem($values, 'iATS Payments Extension', 'iats_settings');
+    Civi::settings()->set('iats_settings', $values);
     parent::postProcess();
   }
 

--- a/CRM/Iats/Upgrader.php
+++ b/CRM/Iats/Upgrader.php
@@ -13,8 +13,8 @@ class CRM_Iats_Upgrader extends CRM_Iats_Upgrader_Base {
     try {
       $xmlfile = CRM_Core_Resources::singleton()->getPath('com.iatspayments.civicrm','info.xml');
       $myxml = simplexml_load_file($xmlfile);
-      $version = (string)$myxml->version;
-      CRM_Core_BAO_Setting::setItem($version, 'iATS Payments Extension', 'iats_extension_version');
+      $version = (string) $myxml->version;
+      Civi::settings()->set('iats_extension_version', $version);
     }
     catch (Exception $e) {
       // ignore
@@ -75,13 +75,13 @@ class CRM_Iats_Upgrader extends CRM_Iats_Upgrader_Base {
 
   public function upgrade_1_4_001() {
     // reset iATS Extension Version in the civicrm_setting table
-    CRM_Core_BAO_Setting::setItem(NULL, 'iATS Payments Extension', 'iats_extension_version');
+    Civi::settings()->set('iats_extension_version', NULL);
     return TRUE;
   }
 
   public function upgrade_1_5_000() {
     // reset iATS Extension Version in the civicrm_setting table
-    CRM_Core_BAO_Setting::setItem(NULL, 'iATS Payments Extension', 'iats_extension_version');
+    Civi::settings()->set('iats_extension_version', NULL);
     return TRUE;
   }
 

--- a/CRM/Iats/iATSServiceRequest.php
+++ b/CRM/Iats/iATSServiceRequest.php
@@ -858,12 +858,12 @@ class CRM_Iats_iATSServiceRequest {
    *
    */
   public static function iats_extension_version($reset = 0) {
-    $version = $reset ? '' : CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_extension_version');
+    $version = $reset ? '' : Civi::settings()->get('iats_extension_version');
     if (empty($version)) {
       $xmlfile = CRM_Core_Resources::singleton()->getPath('com.iatspayments.civicrm', 'info.xml');
       $myxml = simplexml_load_file($xmlfile);
       $version = (string) $myxml->version;
-      CRM_Core_BAO_Setting::setItem($version, 'iATS Payments Extension', 'iats_extension_version');
+      Civi::settings()->set('iats_extension_version', $version);
     }
     return $version;
   }

--- a/api/v3/Job/Fapsquery.php
+++ b/api/v3/Job/Fapsquery.php
@@ -65,9 +65,9 @@ function civicrm_api3_job_fapsquery($params) {
   }
   // CRM_Core_Error::debug_var('Payment Processors', $payment_processors);
   // get the settings: TODO allow more detailed configuration of which transactions to import?
-  $iats_settings = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_settings');
+  $iats_settings = Civi::settings()->get('iats_settings');
   // I also use the settings to keep track of the last time I imported journal data from iATS/FAPS.
-  $iats_faps_journal = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_faps_journal');
+  $iats_faps_journal = Civi::settings()->get('iats_faps_journal');
   /* initialize some values so I can report at the end */
   // count the number of records from each iats account analysed, and the number of each kind found ('action')
   $processed = array();
@@ -132,7 +132,7 @@ function civicrm_api3_job_fapsquery($params) {
   }
   // record the current date into the settings for next time.
   $iats_faps_journal = date('c'); // ISO 8601
-  CRM_Core_BAO_Setting::setItem($iats_faps_journal, 'iATS Payments Extension', 'iats_faps_journal');
+  Civi::settings()->set('iats_faps_journal', $iats_faps_journal);
   $message = '';
   foreach ($processed as $user_name => $p) {
     foreach ($p as $type_id => $count) {

--- a/api/v3/Job/Iatsrecurringcontributions.php
+++ b/api/v3/Job/Iatsrecurringcontributions.php
@@ -105,7 +105,7 @@ function civicrm_api3_job_Iatsrecurringcontributions($params) {
   $counter = 0;
   $error_count  = 0;
   $output  = [];
-  $settings = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_settings');
+  $settings = Civi::settings()->get('iats_settings');
   $receipt_recurring = $settings['receipt_recurring'];
   $email_failure_report = empty($settings['email_recurring_failure_report']) ? '' : $settings['email_recurring_failure_report'];
   // By default, after 3 failures move the next scheduled contribution date forward.

--- a/api/v3/Job/Iatsreport.php
+++ b/api/v3/Job/Iatsreport.php
@@ -65,9 +65,9 @@ function civicrm_api3_job_iatsreport($params) {
   }
   // CRM_Core_Error::debug_var('Payment Processors', $payment_processors);
   // get the settings: TODO allow more detailed configuration of which transactions to import?
-  $iats_settings = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_settings');
+  $iats_settings = Civi::settings()->get('iats_settings');
   // I also use the setttings to keep track of the last time I imported journal data from iATS.
-  $iats_journal = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_journal');
+  $iats_journal = Civi::settings()->get('iats_journal');
   foreach (array('quick', 'recur', 'series') as $setting) {
     $import[$setting] = empty($iats_settings['import_' . $setting]) ? 0 : 1;
   }
@@ -186,7 +186,7 @@ function civicrm_api3_job_iatsreport($params) {
       }
     }
   }
-  CRM_Core_BAO_Setting::setItem($iats_journal, 'iATS Payments Extension', 'iats_journal');
+  Civi::settings()->set('iats_journal', $iats_journal);
   // watchdog('civicrm_iatspayments_com', 'found: <pre>!found</pre>', array('!found' => print_r($processed,TRUE)), WATCHDOG_NOTICE);
   $message = '';
   foreach ($processed as $user_name => $p) {

--- a/api/v3/Job/Iatsverify.php
+++ b/api/v3/Job/Iatsverify.php
@@ -68,7 +68,7 @@ function _civicrm_api3_job_iatsverify_spec(&$spec) {
  */
 function civicrm_api3_job_iatsverify($params) {
 
-  $settings = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_settings');
+  $settings = Civi::settings()->get('iats_settings');
   $receipt_recurring = $settings['receipt_recurring'];
   define('IATS_VERIFY_DAYS', 30);
   // I've added an extra 2 days when getting candidates from CiviCRM to be sure i've got them all.
@@ -107,8 +107,8 @@ function civicrm_api3_job_iatsverify($params) {
   }
   // use these two settings to see if it's worth checking their respective
   // journal tables.
-  $iats_journal_date = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_journal');
-  $iats_faps_journal_date = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_faps_journal');
+  $iats_journal_date = Civi::settings()->get('iats_journal');
+  $iats_faps_journal_date = Civi::settings()->get('iats_faps_journal');
   $message = '';
   try {
     $contributions = civicrm_api3('Contribution', 'get', $select_params);

--- a/iats.php
+++ b/iats.php
@@ -354,7 +354,7 @@ function iats_civicrm_buildForm_CRM_Financial_Form_Payment(&$form) {
 
   // If enabled provide a way to set future contribution dates. 
   // Uses javascript to hide/reset unless they have recurring contributions checked.
-  $settings = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_settings');
+  $settings = Civi::settings()->get('iats_settings');
   if (!empty($settings['enable_public_future_recurring_start'])
     && $form->_paymentObject->supportsFutureRecurStartDate()
   ) {
@@ -478,7 +478,7 @@ function iats_civicrm_pre($op, $objectName, $objectId, &$params) {
   if (('ContributionRecur' == $objectName) && ('create' == $op || 'edit' == $op) && !empty($params['payment_processor_id'])) {
     if ($type = _iats_civicrm_is_iats($params['payment_processor_id'])) {
       if (!empty($params['next_sched_contribution_date'])) {
-        $settings = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_settings');
+        $settings = Civi::settings()->get('iats_settings');
         $allow_days = empty($settings['days']) ? array('-1') : $settings['days'];
         // Force one of the fixed days, and set the cycle_day at the same time.
         if (0 < max($allow_days)) {
@@ -500,7 +500,7 @@ function iats_civicrm_pre($op, $objectName, $objectId, &$params) {
 function iats_get_setting($key = NULL) {
   static $settings;
   if (empty($settings)) { 
-    $settings = CRM_Core_BAO_Setting::getItem('iATS Payments Extension', 'iats_settings');
+    $settings = Civi::settings()->get('iats_settings');
   }
   return empty($key) ?  $settings : (isset($settings[$key]) ? $settings[$key] : '');
 }


### PR DESCRIPTION
…gs facade

ping @adixon @KarinG 

This is in response to the test failures shown up here https://test.civicrm.org/job/CiviCRM-Ext-Matrix/BKPROF=min,BUILDTYPE=git,CIVIVER=master,EXTKEY=com.iatspayments.civicrm,label=bknix-tmp/1582/

also as per the documentation here https://docs.civicrm.org/dev/en/latest/framework/setting/#setting-storage-and-retrieval