### PR TITLE
Replace deprecated doDirectPayment - civicrm-core pr 17456

### DIFF
--- a/CRM/Core/Payment/Faps.php
+++ b/CRM/Core/Payment/Faps.php
@@ -194,7 +194,7 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
 
 
   /**
-   * function doDirectPayment
+   * function doPayment
    *
    * This is the function for taking a payment using a core payment form of any kind.
    *
@@ -206,8 +206,8 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
    * So: the best we can do is to avoid the use of the vault if I'm not using the cryptogram, or if I'm on a page that
    * doesn't offer recurring contributions.
    */
-  public function doDirectPayment(&$params) {
-    // CRM_Core_Error::debug_var('doDirectPayment params', $params);
+  public function doPayment(&$params) {
+    // CRM_Core_Error::debug_var('doPayment params', $params);
 
     // Check for valid currency [todo: we have C$ support, but how do we check,
     // or should we?]

--- a/CRM/Core/Payment/Faps.php
+++ b/CRM/Core/Payment/Faps.php
@@ -363,19 +363,6 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
   }
 
   /**
-   * Todo?
-   *
-   * @param array $params name value pair of contribution data
-   *
-   * @return void
-   * @access public
-   *
-   */
-  function doTransferCheckout( &$params, $component ) {
-    throw new PaymentProcessorException(ts('This function is not implemented'));
-  }
-
-  /**
    * Support corresponding CiviCRM method
    */
   public function changeSubscriptionAmount(&$message = '', $params = array()) {

--- a/CRM/Core/Payment/Faps.php
+++ b/CRM/Core/Payment/Faps.php
@@ -462,7 +462,7 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
       throw new PaymentProcessorException(ts('Error %1', [1 => $error->getMessage()]));
     }
     elseif ($error && is_numeric($error)) {
-      throw new PaymentProcessorExceptionn(ts('Error %1', [1 => $this->errorString($error)]));
+      throw new PaymentProcessorException(ts('Error %1', [1 => $this->errorString($error)]));
     }
     elseif (is_array($error)) {
       $errors = array();

--- a/CRM/Core/Payment/Faps.php
+++ b/CRM/Core/Payment/Faps.php
@@ -153,7 +153,7 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
     $cryptojs = 'https://' . $iats_domain . '/secure/PaymentHostedForm/Scripts/firstpay/firstpay.cryptogram.js';
     $iframe_src = 'https://' . $iats_domain . '/secure/PaymentHostedForm/v3/CreditCard';
     $jsVariables = [
-      'paymentProcessorId' => $this->_paymentProcessor['id'], 
+      'paymentProcessorId' => $this->_paymentProcessor['id'],
       'transcenterId' => $this->_paymentProcessor['password'],
       'processorId' => $this->_paymentProcessor['user_name'],
       'currency' => $form->getCurrency(),
@@ -190,8 +190,7 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
    */
   public function supportsFutureRecurStartDate() {
     return TRUE;
-  } 
-
+  }
 
   /**
    * function doPayment
@@ -202,7 +201,7 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
    * needs to be configured for use with the vault. The cryptogram iframe is created before
    * I know whether the contribution will be recurring or not, so that forces me to always
    * use the vault, if recurring is an option.
-   * 
+   *
    * So: the best we can do is to avoid the use of the vault if I'm not using the cryptogram, or if I'm on a page that
    * doesn't offer recurring contributions.
    */
@@ -255,7 +254,7 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
         'test' => $this->is_test,
       );
       $vault_request = new CRM_Iats_FapsRequest($options);
-      // auto-generate a compliant vault key  
+      // auto-generate a compliant vault key
       $vault_key = self::generateVaultKey($request['ownerEmail']);
       $request['vaultKey'] = $vault_key;
       $request['ipAddress'] = $ipAddress;
@@ -373,7 +372,7 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
    *
    */
   function doTransferCheckout( &$params, $component ) {
-    CRM_Core_Error::fatal(ts('This function is not implemented'));
+    throw new PaymentProcessorException(ts('This function is not implemented'));
   }
 
   /**
@@ -472,18 +471,11 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
    *
    */
   public function &error($error = NULL) {
-    $e = CRM_Core_Error::singleton();
     if (is_object($error)) {
-      $e->push($error->getResponseCode(),
-        0, NULL,
-        $error->getMessage()
-      );
+      throw new PaymentProcessorException(ts('Error %1', [1 => $error->getMessage()]));
     }
     elseif ($error && is_numeric($error)) {
-      $e->push($error,
-        0, NULL,
-        $this->errorString($error)
-      );
+      throw new PaymentProcessorExceptionn(ts('Error %1', [1 => $this->errorString($error)]));
     }
     elseif (is_array($error)) {
       $errors = array();
@@ -498,13 +490,10 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
         }
       }
       $error_string = implode('<br />',$errors);
-      $e->push(9002,
-        0, NULL,
-        $error_string
-      );
+      throw new PaymentProcessorException(ts('Error %1', [1 => $error_string]));
     }
     else {
-      $e->push(9001, 0, NULL, "Unknown System Error.");
+      throw new PaymentProcessorException(ts('Unknown System Error.', 9001));
     }
     return $e;
   }

--- a/CRM/Core/Payment/FapsACH.php
+++ b/CRM/Core/Payment/FapsACH.php
@@ -97,13 +97,13 @@ class CRM_Core_Payment_FapsACH extends CRM_Core_Payment_Faps {
 
 
   /**
-   * function doDirectPayment
+   * function doPayment
    *
    * This is the function for taking a payment using a core payment form of any kind.
    *
    */
-  public function doDirectPayment(&$params) {
-    // CRM_Core_Error::debug_var('doDirectPayment params', $params);
+  public function doPayment(&$params) {
+    // CRM_Core_Error::debug_var('doPayment params', $params);
 
     // Check for valid currency
     $currency = $params['currencyID'];

--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -310,29 +310,18 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
    *
    */
   public function &error($error = NULL) {
-    $e = CRM_Core_Error::singleton();
     if (is_object($error)) {
-      $e->push($error->getResponseCode(),
-        0, NULL,
-        $error->getMessage()
-      );
+      throw new CRM_Core_Exception(ts("Error %1", [1 => $error->getMessage()]));
     }
     elseif ($error && is_numeric($error)) {
-      $e->push($error,
-        0, NULL,
-        $this->errorString($error)
-      );
+      throw new CRM_Core_Exception(ts("Error %1", [1 => $this->errorString($error)]));
     }
     elseif (is_string($error)) {
-      $e->push(9002,
-        0, NULL,
-        $error
-      );
+      throw new CRM_Core_Exception(ts("Error %1", [1 => $error]));
     }
     else {
-      $e->push(9001, 0, NULL, "Unknown System Error.");
+      throw new CRM_Core_Exception(ts("Unknown System Error."));
     }
-    return $e;
   }
 
   /**

--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -314,7 +314,7 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
       throw new PaymentProcessorException(ts('Error %1', [1 => $error->getMessage()]));
     }
     elseif ($error && is_numeric($error)) {
-      throw new PaymentProcessorExceptionn(ts('Error %1', [1 => $this->errorString($error)]));
+      throw new PaymentProcessorException(ts('Error %1', [1 => $this->errorString($error)]));
     }
     elseif (is_string($error)) {
       throw new PaymentProcessorException(ts('Error %1', [1 => $error]));

--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -126,7 +126,7 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
   /**
    *
    */
-  public function doDirectPayment(&$params) {
+  public function doPayment(&$params) {
 
     if (!$this->_profile) {
       return self::error('Unexpected error, missing profile');

--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -121,7 +121,7 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
    */
   public function supportsFutureRecurStartDate() {
     return TRUE;
-  } 
+  }
 
   /**
    *
@@ -214,7 +214,7 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
         $today = date('Ymd');
         // If the receive_date is NOT today, then
         // create a pending contribution and adjust the next scheduled date.
-        CRM_Core_Error::debug_var('receive_date', $receieve_date);
+        CRM_Core_Error::debug_var('receive_date', $receive_date);
         if ($receive_date !== $today) {
           // I've got a schedule to adhere to!
           // set the receieve time to 3:00 am for a better admin experience
@@ -240,7 +240,7 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
           $response = $iats->request($credentials, $request);
           $result = $iats->result($response);
           if ($result['status']) {
-            // Add a time string to iATS short authentication string to ensure 
+            // Add a time string to iATS short authentication string to ensure
             // uniqueness and provide helpful referencing.
             $update = array(
               'trxn_id' => trim($result['remote_id']) . ':' . time(),
@@ -285,7 +285,7 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
   /**
    * Set additional fields when editing the schedule.
    *
-   * Note: this doesn't completely replace the form hook, which is still 
+   * Note: this doesn't completely replace the form hook, which is still
    * in use for additional changes, and to support 4.6.
    * e.g. the commented out fields below don't work properly here.
    */
@@ -311,16 +311,16 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
    */
   public function &error($error = NULL) {
     if (is_object($error)) {
-      throw new CRM_Core_Exception(ts("Error %1", [1 => $error->getMessage()]));
+      throw new PaymentProcessorException(ts('Error %1', [1 => $error->getMessage()]));
     }
     elseif ($error && is_numeric($error)) {
-      throw new CRM_Core_Exception(ts("Error %1", [1 => $this->errorString($error)]));
+      throw new PaymentProcessorExceptionn(ts('Error %1', [1 => $this->errorString($error)]));
     }
     elseif (is_string($error)) {
-      throw new CRM_Core_Exception(ts("Error %1", [1 => $error]));
+      throw new PaymentProcessorException(ts('Error %1', [1 => $error]));
     }
     else {
-      throw new CRM_Core_Exception(ts("Unknown System Error."));
+      throw new PaymentProcessorException(ts('Unknown System Error.', 9001));
     }
   }
 
@@ -427,8 +427,8 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
     if (empty($params['crid'])) {
       $params['crid'] = !empty($_POST['crid']) ? (int) $_POST['crid'] : (!empty($_GET['crid']) ? (int) $_GET['crid'] : 0);
       if (empty($params['crid']) && !empty($params['entryURL'])) {
-        $components = parse_url($params['entryURL']); 
-        parse_str(html_entity_decode($components['query']), $entryURLquery); 
+        $components = parse_url($params['entryURL']);
+        parse_str(html_entity_decode($components['query']), $entryURLquery);
         $params['crid'] = $entryURLquery['crid'];
       }
     }
@@ -437,7 +437,7 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
     if (empty($crid)) {
       $alert = ts('This system is unable to perform self-service updates to credit cards. Please contact the administrator of this site.');
       throw new Exception($alert);
-    } 
+    }
     $mop = array(
       'Visa' => 'VISA',
       'MasterCard' => 'MC',
@@ -491,12 +491,12 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
       }
       return $this->error('9002','Authorization failed');
     }
-    catch (Exception $error) { // what could go wrong? 
+    catch (Exception $error) { // what could go wrong?
       $message = $error->getMessage();
       return $this->error('9002', $message);
     }
   }
-  
+
   /*
    * Update the recurring contribution record.
    *
@@ -510,7 +510,7 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
   protected function updateRecurring($params, $update) {
     // If the recurring record already exists, let's fix the next contribution and start dates,
     // in case core isn't paying attention.
-    // We also set the schedule to 'in-progress' (even for ACH/EFT when the first one hasn't been verified), 
+    // We also set the schedule to 'in-progress' (even for ACH/EFT when the first one hasn't been verified),
     // because we want the recurring job to run for this schedule.
     if (!empty($params['contributionRecurID'])) {
       $recur_id = $params['contributionRecurID'];

--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -214,7 +214,6 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
         $today = date('Ymd');
         // If the receive_date is NOT today, then
         // create a pending contribution and adjust the next scheduled date.
-        CRM_Core_Error::debug_var('receive_date', $receive_date);
         if ($receive_date !== $today) {
           // I've got a schedule to adhere to!
           // set the receieve time to 3:00 am for a better admin experience

--- a/CRM/Core/Payment/iATSServiceACHEFT.php
+++ b/CRM/Core/Payment/iATSServiceACHEFT.php
@@ -113,7 +113,7 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   public function buildForm(&$form) {
-    // If a form allows ACH/EFT and enables recurring, set recurring to the default. 
+    // If a form allows ACH/EFT and enables recurring, set recurring to the default.
     if (isset($form->_elementIndex['is_recur'])) {
       // Make recurring contrib default to true.
       $form->setDefaults(array('is_recur' => 1));
@@ -161,7 +161,7 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
       'template' => 'CRM/Iats/BillingBlockDirectDebitExtra_USD.tpl',
     ));
   }
-  
+
   /**
    * Customization for CAD ACH-EFT billing block.
    *
@@ -327,7 +327,7 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
               'gross_amount' => $params['amount'],
               'payment_status_id' => 2,
             );
-            // Setting the next_sched_contribution_date param doesn't do anything, 
+            // Setting the next_sched_contribution_date param doesn't do anything,
             // work around in updateRecurring
             $this->updateRecurring($params, $update);
             $params = array_merge($params, $update);
@@ -376,32 +376,22 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
    *
    */
   public function &error($error = NULL) {
-    $e = CRM_Core_Error::singleton();
     if (is_object($error)) {
-      $e->push($error->getResponseCode(),
-        0, NULL,
-        $error->getMessage()
-      );
+      throw new PaymentProcessorException(ts('Error %1', [1 => $error->getMessage()]));
     }
     elseif ($error && is_numeric($error)) {
-      $e->push($error,
-        0, NULL,
-        $this->errorString($error)
-      );
+      throw new PaymentProcessorExceptionn(ts('Error %1', [1 => $this->errorString($error)]));
     }
     elseif (is_string($error)) {
-      $e->push(9002,
-        0, NULL,
-        $error
-      );
+      throw new PaymentProcessorException(ts('Error %1', [1 => $error]));
     }
     else {
-      $e->push(9001, 0, NULL, "Unknown System Error.");
+      throw new PaymentProcessorException(ts('Unknown System Error.', 9001));
     }
     return $e;
   }
 
- /** 
+ /**
    * Are back office payments supported.
    *
    * @return bool
@@ -409,7 +399,7 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
   protected function supportsBackOffice() {
     return TRUE;
   }
-    
+
  /**
    * This function checks to see if we have the right config values.
    *

--- a/CRM/Core/Payment/iATSServiceACHEFT.php
+++ b/CRM/Core/Payment/iATSServiceACHEFT.php
@@ -380,7 +380,7 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
       throw new PaymentProcessorException(ts('Error %1', [1 => $error->getMessage()]));
     }
     elseif ($error && is_numeric($error)) {
-      throw new PaymentProcessorExceptionn(ts('Error %1', [1 => $this->errorString($error)]));
+      throw new PaymentProcessorException(ts('Error %1', [1 => $this->errorString($error)]));
     }
     elseif (is_string($error)) {
       throw new PaymentProcessorException(ts('Error %1', [1 => $error]));

--- a/CRM/Core/Payment/iATSServiceACHEFT.php
+++ b/CRM/Core/Payment/iATSServiceACHEFT.php
@@ -200,7 +200,7 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
   /**
    *
    */
-  public function doDirectPayment(&$params) {
+  public function doPayment(&$params) {
 
     if (!$this->_profile) {
       return self::error('Unexpected error, missing profile');

--- a/js/dpm.js
+++ b/js/dpm.js
@@ -1,9 +1,9 @@
-/* 
- * custom js for direct post method 
+/*
+ * custom js for direct post method
  *
  * Intercept the normal submission of sensitive billing data,
  * submit it in the background via ajax
- * and include the results for parsing by the payment processor doDirectPayment script
+ * and include the results for parsing by the payment processor doPayment script
  * while masking out the credit card information
  */
 
@@ -52,13 +52,13 @@ cj(function ($) {
       dpmPOST.IATS_DPM_ZipCode = $('input[name|="billing_postal_code"]').val();
       dpmPOST.IATS_DPM_Country = $('select[name|="billing_country_id"]').find('selected').text();
       dpmPOST.IATS_DPM_Email = $('input[name|="email"]').val();
-      
+
       dpmPOST.IATS_DPM_AccountNumber = $('#credit_card_number').val();
       var Month = $('#credit_card_exp_date_M').val();
       var Year = $('#credit_card_exp_date_Y').val();
       dpmPOST.IATS_DPM_ExpiryDate = Month+'/'+Year.substr(2);
       dpmPOST.IATS_DPM_CVV2 = $('#cvv2').val();
-      // todo: translate mop values 
+      // todo: translate mop values
       dpmPOST.IATS_DPM_MOP = $('#credit_card_type').val();
       dpmPOST.IATS_DPM_Amount = $('.contribution_amount-section input:checked').prop('data-amount');
       console.log(dpmPOST);
@@ -67,7 +67,7 @@ cj(function ($) {
         type: 'POST',
         url: dpmURL,
         data: dpmPOST,
-        dataType: 'json', 
+        dataType: 'json',
         async: false,
         success: function(result) {
           console.log(result);


### PR DESCRIPTION
Ok - initial testing:
- works fine to complete a credit card transaction that is authorized etc.

Does not handle card rejections -> to reproduce:
Try process Total Amount -> 3000 (that's above the fake VISA limit...)
Select: CREDIT CARD TEST88
use card number 4222222222222220
Confirm Contribution -> 
Fatal errror ->

`Error: Cannot use object of type CRM_Core_Error as array in CRM_Contribute_BAO_Contribution_Utils::processConfirm() (line 176 of /var/www/html/sites/all/modules/civicrm/CRM/Contribute/BAO/Contribution/Utils.php).`

I saw this note:
"Payment processors should throw exceptions and not return Error objects as they may have done with the old functions."