### PR TITLE
[REF] Fix declaration of do Payment to be the same as CRM_Core_Paymen…

### DIFF
--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -125,7 +125,7 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
   /**
    *
    */
-  public function doPayment(&$params) {
+  public function doPayment(&$params, $component = 'contribute') {
 
     if (!$this->_profile) {
       return self::error('Unexpected error, missing profile');


### PR DESCRIPTION
…t::doPayment(&,  = 'contribute')

This fixes a notice shown on the ext-matrix tests for IATS

```
CRM_Iats_ContributioniATSTest::testIATSCreditCardBackend
Failure in api call for PaymentProcessor create:  Declaration of CRM_Core_Payment_iATSService::doPayment(&$params) should be compatible with CRM_Core_Payment::doPayment(&$params, $component = 'contribute')
```
