### PR TITLE
Fix detection of IATs processor

### DIFF
--- a/iats.php
+++ b/iats.php
@@ -551,7 +551,7 @@ function _iats_civicrm_is_iats($payment_processor_id) {
   }
   // type is class name with Payment_ stripped from the front
   $type = substr($result['class_name'], 8);
-  $is_iats = (0 == strpos($type, 'iATSService')) || (0 == strpos($type, 'Faps'));
+  $is_iats = (0 === strpos($type, 'iATSService')) || (0 === strpos($type, 'Faps'));
   return ($is_iats ? $type : FALSE);
 }
 


### PR DESCRIPTION
(0 == strpos()) matches when strpos() returns FALSE. (0 === strpos()) only matches when strpos() returns 0.

This causes false positives for the "Is IATs" check.