### PR TITLE
WIP implement doCancelRecurring

### DIFF
--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -22,6 +22,7 @@
  */
 
 use Civi\Payment\Exception\PaymentProcessorException;
+use Civi\Payment\PropertyBag;
 
 /**
  *
@@ -275,11 +276,22 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
 
   /**
    * support corresponding CiviCRM method
+   * ToDo: deprecated -> remove when ESR has a security update which will bring everyone >5.27
    */
   public function cancelSubscription(&$message = '', $params = array()) {
     $userAlert = ts('You have cancelled this recurring contribution.');
     CRM_Core_Session::setStatus($userAlert, ts('Warning'), 'alert');
     return TRUE;
+  }
+
+  /**
+   * support corresponding CiviCRM method
+   * preferred function for Cancelling a Recurring Contribution as of 5.25
+   *
+   * @return array|null[]
+   */
+  public function doCancelRecurring(PropertyBag $propertyBag) {
+    return ['message' => ts('You have cancelled this recurring contribution.')];
   }
 
   /**


### PR DESCRIPTION
WIP - my ITEM 3:

```
ITEM3 - Cancelling a Recurring Contribution

1. The method doCancelRecurring() was added in CiviCRM 5.25 https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Payment.php#L1411 and is now the preferred function for Cancelling a Recurring Contribution! For older versions of CiviCRM you need to implement cancelSubscription().

2. Note: from CiviCRM 5.25 cancelSubscription() will receive a \Civi\Payment\PropertyBag and NOT an array. So -> if you are using array_ functions to interact with the $params that will no longer work as it is no longer an array. If you don't use array_ functions in your cancelSubscription() you will require no change! Note you can cast a $params array to $propertyBag to take advantage of it already.

3. The payment class should implement the following methods:

protected function supportsCancelRecurring() { return TRUE; } CiviCRM will show cancellation links based on this. 

4. Examples:
Fancy example: Stripe implementation -> https://lab.civicrm.org/extensions/stripe/-/blob/6.4.1/CRM/Core/Payment/Stripe.php#L975

Simple example: iATSPayments -> added a new function doCancelRecurring() & marked cancelSubscription() as to be deprecated in future [this PR]

If you are supporting ESR -> note that current ESR is 5.27 but many sites will still be on 5.21.x b/c there has not been a security advisory (yet). 

```