### PR TITLE
Backoffice contribution credit card form unable to update the billing block

### DIFF
--- a/iats.php
+++ b/iats.php
@@ -339,9 +339,9 @@ function iats_civicrm_buildForm($formName, &$form) {
  * Modifications to a (public/frontend) contribution financial forms for iATS
  * procesors.
  * 1. enable public selection of future recurring contribution start date.
- * 
+ *
  * We're only handling financial payment class forms here. Note that we can no
- * longer test for whether the page has/is recurring or not. 
+ * longer test for whether the page has/is recurring or not.
  */
 
 function iats_civicrm_buildForm_CRM_Financial_Form_Payment(&$form) {
@@ -352,7 +352,7 @@ function iats_civicrm_buildForm_CRM_Financial_Form_Payment(&$form) {
     return;
   }
 
-  // If enabled provide a way to set future contribution dates. 
+  // If enabled provide a way to set future contribution dates.
   // Uses javascript to hide/reset unless they have recurring contributions checked.
   $settings = Civi::settings()->get('iats_settings');
   if (!empty($settings['enable_public_future_recurring_start'])
@@ -397,7 +397,7 @@ function iats_civicrm_pageRun(&$page) {
  * link to iATS CustomerLink display and editing pages.
  */
 function iats_civicrm_pageRun_CRM_Contribute_Page_ContributionRecur($page) {
-  // Get the corresponding (most recently created) iATS customer code record 
+  // Get the corresponding (most recently created) iATS customer code record
   // we'll also get the expiry date and last four digits (at least, our best information about that).
   $extra = array();
   $crid = CRM_Utils_Request::retrieve('id', 'Integer', $page, FALSE);
@@ -499,7 +499,7 @@ function iats_civicrm_pre($op, $objectName, $objectId, &$params) {
 
 function iats_get_setting($key = NULL) {
   static $settings;
-  if (empty($settings)) { 
+  if (empty($settings)) {
     $settings = Civi::settings()->get('iats_settings');
   }
   return empty($key) ?  $settings : (isset($settings[$key]) ? $settings[$key] : '');
@@ -595,7 +595,7 @@ function _iats_get_form_payment_processors($form) {
     $id = $form->_paymentProcessor['id'];
     return array($id => $form->_paymentProcessor);
   }
-  else { 
+  else {
     // Handle the legacy: event and contribution page forms
     if (empty($form->_paymentProcessors)) {
       if (empty($form->_paymentProcessorIDs)) {
@@ -619,12 +619,13 @@ function iats_getCurrency($form) {
   $form_class = get_class($form);
   $currency = '';
   switch($form_class) {
-    case 'CRM_Contribute_Form_Contribution':
     case 'CRM_Contribute_Form_Contribution_Main':
     case 'CRM_Member_Form_Membership':
       $currency = $form->_values['currency'];
       break;
+
     case 'CRM_Financial_Form_Payment':
+    case 'CRM_Contribute_Form_Contribution':
       // This is the new ajax-loaded payment form.
       $currency = $form->getCurrency();
       break;
@@ -633,6 +634,7 @@ function iats_getCurrency($form) {
       $currency = $form->_values['event']['currency'];
       break;
   }
+
   if (empty($currency)) {
     // This may occur in edge cases, so don't break, though the form won't be rendered correctly.
     // See comment on civicrm core commit f61437d
@@ -714,7 +716,7 @@ function iats_civicrm_buildForm_CRM_Contribute_Form_UpdateSubscription(&$form) {
   }
   $allow_days = empty($settings['days']) ? array('-1') : $settings['days'];
   if (0 < max($allow_days)) {
-    $userAlert = ts('Your next scheduled contribution date will automatically be updated to the next allowable day of the month: %1', 
+    $userAlert = ts('Your next scheduled contribution date will automatically be updated to the next allowable day of the month: %1',
       array(1 => implode(', ', $allow_days)));
     CRM_Core_Session::setStatus($userAlert, ts('Warning'), 'alert');
   }
@@ -747,7 +749,7 @@ function iats_civicrm_buildForm_CRM_Contribute_Form_UpdateSubscription(&$form) {
     'is_email_receipt' => 'Email receipt for each Contribution in this Recurring Series',
   );
   $dupe_fields = array();
-  // To be a good citizen, I check if core or another extension hasn't already added these fields 
+  // To be a good citizen, I check if core or another extension hasn't already added these fields
   // and don't add them again if they have.
   foreach (array_keys($edit_fields) as $fid) {
     if ($form->elementExists($fid)) {


### PR DESCRIPTION
Overview
----------------------------------------
Steps to replicate:

1. Install and enable iATS paymentextension
2. Add and configure an iATS Payments ACH/EFT payment type payment processor.
3. Enable USD and CAD currencies
4. Go to 'Submit Credit Card Contribution' backoffice form
5. Choose payment processor created at step 2

Issue:
1. Payment block renders payment block without check template
2. Switching currency doesn't update the payment block.


Before
----------------------------------------
![crm-598-before](https://user-images.githubusercontent.com/3735621/93595871-22c6e880-f9d6-11ea-893a-884f70be05e8.gif)


After
----------------------------------------
![crm-598-after](https://user-images.githubusercontent.com/3735621/93595901-2bb7ba00-f9d6-11ea-8de7-93f12e4de516.gif)


ping @adixon @eileenmcnaughton @KarinG