### PR TITLE
Remove unused gross_amount.

### DIFF
--- a/CRM/Core/Payment/Faps.php
+++ b/CRM/Core/Payment/Faps.php
@@ -377,7 +377,6 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
       // For versions >= 4.6.6, the proper key.
       $params['payment_status_id'] = 1;
       $params['trxn_id'] = trim($result['data']['referenceNumber']).':'.time();
-      $params['gross_amount'] = $params['amount'];
       return $params;
     }
     else {
@@ -439,7 +438,7 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
         $result = civicrm_api3('Country', 'get', [
           'sequential' => 1,
           'return' => ['name'],
-	  'id' => $params['country_id'], 
+	  'id' => $params['country_id'],
           'options' => ['limit' => 1],
         ]);
 	$params['country'] = $result['values'][0]['name'];
@@ -453,7 +452,7 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
         $result = civicrm_api3('StateProvince', 'get', [
           'sequential' => 1,
           'return' => ['name'],
-	  'id' => $params['state_province_id'], 
+	  'id' => $params['state_province_id'],
           'options' => ['limit' => 1],
         ]);
 	$params['state_province'] = $result['values'][0]['name'];

--- a/CRM/Core/Payment/FapsACH.php
+++ b/CRM/Core/Payment/FapsACH.php
@@ -37,7 +37,7 @@ class CRM_Core_Payment_FapsACH extends CRM_Core_Payment_Faps {
     $this->_mode             = $mode;
     $this->_paymentProcessor = $paymentProcessor;
     $this->disable_cryptogram    = iats_get_setting('disable_cryptogram');
-    $this->is_test = ($this->_mode == 'test' ? 1 : 0); 
+    $this->is_test = ($this->_mode == 'test' ? 1 : 0);
   }
 
   /**
@@ -104,11 +104,11 @@ class CRM_Core_Payment_FapsACH extends CRM_Core_Payment_Faps {
     ));
     // and now add in a helpful cheque image and description
     switch($currency) {
-      case 'USD': 
+      case 'USD':
         CRM_Core_Region::instance('billing-block')->add(array(
           'template' => 'CRM/Iats/BillingBlockFapsACH_USD.tpl',
         ));
-      case 'CAD': 
+      case 'CAD':
         CRM_Core_Region::instance('billing-block')->add(array(
           'template' => 'CRM/Iats/BillingBlockFapsACH_CAD.tpl',
         ));
@@ -151,7 +151,7 @@ class CRM_Core_Payment_FapsACH extends CRM_Core_Payment_Faps {
       );
       $vault_request = new CRM_Iats_FapsRequest($options);
       $request = $this->convertParams($params, $options['action']);
-      // auto-generate a compliant vault key  
+      // auto-generate a compliant vault key
       $vault_key = self::generateVaultKey($request['ownerEmail']);
       $request['vaultKey'] = $vault_key;
       $request['ipAddress'] = $ipAddress;
@@ -216,7 +216,6 @@ class CRM_Core_Payment_FapsACH extends CRM_Core_Payment_Faps {
     if ($success) {
       $params['payment_status_id'] = 2;
       $params['trxn_id'] = trim($result['data']['referenceNumber']).':'.time();
-      $params['gross_amount'] = $params['amount'];
       // Core assumes that a pending result will have no transaction id, but we have a useful one.
       if (!empty($params['contributionID'])) {
         $contribution_update = array('id' => $params['contributionID'], 'trxn_id' => $params['trxn_id']);
@@ -237,7 +236,7 @@ class CRM_Core_Payment_FapsACH extends CRM_Core_Payment_Faps {
   }
 
   /**
-   * Get the category text. 
+   * Get the category text.
    * Before I return it, check that the category text exists, and create it if
    * it doesn't.
    *
@@ -257,7 +256,7 @@ class CRM_Core_Payment_FapsACH extends CRM_Core_Payment_Faps {
     static $ach_category_text_saved;
     if (!empty($ach_category_text_saved)) {
       return $ach_category_text_saved;
-    } 
+    }
     $ach_category_text = iats_get_setting('ach_category_text');
     $ach_category_text = empty($ach_category_text) ? FAPS_DEFAULT_ACH_CATEGORY_TEXT : $ach_category_text;
     $ach_category_exists = FALSE;

--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -155,7 +155,6 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
         // Success.
         $params['payment_status_id'] = 1;
         $params['trxn_id'] = trim($result['remote_id']) . ':' . time();
-        $params['gross_amount'] = $params['amount'];
         return $params;
       }
       else {
@@ -244,7 +243,6 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
             // uniqueness and provide helpful referencing.
             $update = array(
               'trxn_id' => trim($result['remote_id']) . ':' . time(),
-              'gross_amount' => $params['amount'],
               'payment_status_id' => 1,
             );
             // do some cleanups to the recurring record in updateRecurring

--- a/CRM/Core/Payment/iATSServiceACHEFT.php
+++ b/CRM/Core/Payment/iATSServiceACHEFT.php
@@ -226,7 +226,6 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
       if ($result['status']) {
         $params['payment_status_id'] = 2;
         $params['trxn_id'] = trim($result['remote_id']) . ':' . time();
-        $params['gross_amount'] = $params['amount'];
         // Core assumes that a pending result will have no transaction id, but we have a useful one.
         if (!empty($params['contributionID'])) {
           $contribution_update = array('id' => $params['contributionID'], 'trxn_id' => $params['trxn_id']);
@@ -325,7 +324,6 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
             // Add a time string to iATS short authentication string to ensure uniqueness and provide helpful referencing.
             $update = array(
               'trxn_id' => trim($result['remote_id']) . ':' . time(),
-              'gross_amount' => $params['amount'],
               'payment_status_id' => 2,
             );
             // Setting the next_sched_contribution_date param doesn't do anything,


### PR DESCRIPTION
Small clean up PR. Explained here by @eileenmcnaughton - https://github.com/civicrm/civicrm-core/pull/18177 -> gross_amount is unused and removing it helps clarify it as unnecessary & unused.



