### PR TITLE
Use name instead of hard coded ids in the PaymentProcessor Type field

### DIFF
--- a/tests/phpunit/CRM/Iats/ContributionIATSTest.php
+++ b/tests/phpunit/CRM/Iats/ContributionIATSTest.php
@@ -227,7 +227,7 @@ class CRM_Iats_ContributioniATSTest extends BaseTestClass {
     $processorParams = array(
       'domain_id' => 1,
       'name' => 'iATS Credit Card - TE4188',
-      'payment_processor_type_id' => 15,
+      'payment_processor_type_id' => 'iATS Payments Credit Card',
       'financial_account_id' => 12,
       'is_test' => FALSE,
       'is_active' => 1,
@@ -257,7 +257,7 @@ class CRM_Iats_ContributioniATSTest extends BaseTestClass {
     $processorParams = array(
       'domain_id' => 1,
       'name' => 'iATS Credit Card - TE4188',
-      'payment_processor_type_id' => 17,
+      'payment_processor_type_id' => 'iATS Payments SWIPE',
       'financial_account_id' => 12,
       'is_test' => FALSE,
       'is_active' => 1,


### PR DESCRIPTION
This aims to fix the following failure https://test.civicrm.org/job/CiviCRM-Ext-Matrix/BKPROF=min,BUILDTYPE=normal,CIVIVER=master,EXTKEY=com.iatspayments.civicrm,label=bknix-tmp/lastCompletedBuild/testReport/(root)/CRM_Iats_ContributioniATSTest/testIATSSWIPEBackend/

@KarinG 