### PR TITLE
for legacy processor transactions, always populate result[auth_code],…

### DIFF
--- a/CRM/Iats/Transaction.php
+++ b/CRM/Iats/Transaction.php
@@ -358,9 +358,10 @@ class CRM_Iats_Transaction {
         // Process the soap response into a readable result.
         $result['result'] = $iats->result($response);
         $result['success'] = !empty($result['result']['status']);
+        $result['auth_code'] = $result['result']['auth_result'];
         if ($result['success']) {
           $result['trxn_id'] = trim($result['result']['remote_id']) . ':' . time();
-          $result['message'] = $result['auth_code'] = $result['result']['auth_result'];
+          $result['message'] = $result['auth_code'];
         }
         else {
           $result['message'] = $result['result']['reasonMessage'];


### PR DESCRIPTION
… even on failures

As per https://github.com/iATSPayments/com.iatspayments.civicrm/issues/301