### PR TITLE
Support 0 amount payments (eg. cividiscount)

### DIFF
--- a/CRM/Core/Payment/FapsACH.php
+++ b/CRM/Core/Payment/FapsACH.php
@@ -126,6 +126,14 @@ class CRM_Core_Payment_FapsACH extends CRM_Core_Payment_Faps {
   public function doPayment(&$params, $component = 'contribute') {
     // CRM_Core_Error::debug_var('doPayment params', $params);
 
+    /* @var \Civi\Payment\PropertyBag $propertyBag */
+    $propertyBag = \Civi\Payment\PropertyBag::cast($params);
+
+    $zeroAmountPayment = $this->processZeroAmountPayment($propertyBag);
+    if ($zeroAmountPayment) {
+      return $zeroAmountPayment;
+    }
+
     // Check for valid currency
     $currency = $params['currencyID'];
     if (('USD' != $currency) && ('CAD' != $currency)) {

--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -27,6 +27,7 @@ use Civi\Payment\Exception\PaymentProcessorException;
  *
  */
 class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
+  use CRM_Core_Payment_iATSTrait;
 
   /**
    * We only need one instance of this object. So we use the singleton
@@ -169,6 +170,13 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
    *
    */
   public function doPayment(&$params, $component = 'contribute') {
+    /* @var \Civi\Payment\PropertyBag $propertyBag */
+    $propertyBag = \Civi\Payment\PropertyBag::cast($propertyBag);
+
+    $zeroAmountPayment = $this->processZeroAmountPayment($propertyBag);
+    if ($zeroAmountPayment) {
+      return $zeroAmountPayment;
+    }
 
     if (!$this->_profile) {
       return self::error('Unexpected error, missing profile');

--- a/CRM/Core/Payment/iATSServiceACHEFT.php
+++ b/CRM/Core/Payment/iATSServiceACHEFT.php
@@ -28,6 +28,7 @@ use Civi\Payment\Exception\PaymentProcessorException;
  *
  */
 class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
+  use CRM_Core_Payment_iATSTrait;
 
   /**
    * We only need one instance of this object. So we use the singleton
@@ -202,6 +203,13 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
    *
    */
   public function doPayment(&$params, $component = 'contribute') {
+    /* @var \Civi\Payment\PropertyBag $propertyBag */
+    $propertyBag = \Civi\Payment\PropertyBag::cast($params);
+
+    $zeroAmountPayment = $this->processZeroAmountPayment($propertyBag);
+    if ($zeroAmountPayment) {
+      return $zeroAmountPayment;
+    }
 
     if (!$this->_profile) {
       return self::error('Unexpected error, missing profile');

--- a/CRM/Core/Payment/iATSServiceSWIPE.php
+++ b/CRM/Core/Payment/iATSServiceSWIPE.php
@@ -27,6 +27,7 @@ use Civi\Payment\Exception\PaymentProcessorException;
  *
  */
 class CRM_Core_Payment_iATSServiceSWIPE extends CRM_Core_Payment_iATSService {
+  use CRM_Core_Payment_iATSTrait;
 
   /**
    * We only need one instance of this object. So we use the singleton

--- a/CRM/Core/Payment/iATSTrait.php
+++ b/CRM/Core/Payment/iATSTrait.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use CRM_Iats_ExtensionUtil as E;
+/**
+ * Shared payment functions that should one day be migrated to CiviCRM core
+ * Trait CRM_Core_Payment_iATSTrait (some functions copied from CRM_Core_Payment_MJWTrait
+ */
+trait CRM_Core_Payment_iATSTrait {
+
+  /**
+   * In some cases a payment is still submitted via the payment processor with zero amount.
+   * See eg. https://lab.civicrm.org/extensions/stripe/-/issues/256.
+   * When you have a 0 membership option and a confirmation page.
+   * This function should be called in doPayment() before beginDoPayment()
+   *
+   * @param \Civi\Payment\PropertyBag $propertyBag
+   *
+   * @return array|false
+   */
+  protected function processZeroAmountPayment(\Civi\Payment\PropertyBag $propertyBag) {
+    // If we have a $0 amount, skip call to processor and set payment_status to Completed.
+    // https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Payment.php#L1362
+    if ($propertyBag->getAmount() == 0) {
+      return $this->setStatusPaymentCompleted([]);
+    }
+    else {
+      return FALSE;
+    }
+  }
+
+  /**
+   * Set the payment status to Pending
+   * @param array $params
+   *
+   * @return array
+   */
+  protected function setStatusPaymentPending(array $params) {
+    $params['payment_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending');
+    $params['payment_status'] = 'Pending';
+    return $params;
+  }
+
+  /**
+   * Set the payment status to Completed
+   * @param $params
+   *
+   * @return array
+   */
+  protected function setStatusPaymentCompleted(array $params) {
+    $params['payment_status_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
+    $params['payment_status'] = 'Completed';
+    return $params;
+  }
+
+}


### PR DESCRIPTION
This is a "quick" fix for https://github.com/iATSPayments/com.iatspayments.civicrm/issues/362 modelled on exactly how Stripe/MJWShared implements it.

It could probably be simplified but it's basically a direct copy from https://lab.civicrm.org/extensions/mjwshared/-/blob/master/CRM/Core/Payment/MJWTrait.php#L453

I prefer to build functions taking the payment propertyBag as input because they don't need converting in future (effectively it just means it's using a consistent set of params at this stage).

It introduces a shared PHP "Trait" that can be used between all the payment processor types you have in iATS.