### PR TITLE
Update unit tests for alternate to testSubmit

### DIFF
--- a/tests/phpunit/CRM/Iats/BaseTestClass.php
+++ b/tests/phpunit/CRM/Iats/BaseTestClass.php
@@ -31,4 +31,58 @@ abstract class BaseTestClass extends \PHPUnit\Framework\TestCase implements Head
       ->apply();
   }
 
+  /**
+   * Copied from civicrm core CiviUnitTestCase.
+   *
+   * Instantiate form object.
+   *
+   * We need to instantiate the form to run preprocess, which means we have to trick it about the request method.
+   *
+   * @param string $class
+   *   Name of form class.
+   *
+   * @param array $formValues
+   *
+   * @param string $pageName
+   *
+   * @param array $searchFormValues
+   *   Values for the search form if the form is a task eg.
+   *   for selected ids 6 & 8:
+   *   [
+   *      'radio_ts' => 'ts_sel',
+   *      'task' => CRM_Member_Task::PDF_LETTER,
+   *      'mark_x_6' => 1,
+   *      'mark_x_8' => 1,
+   *   ]
+   *
+   * @return \CRM_Core_Form
+   */
+  public function getFormObject($class, $formValues = [], $pageName = '', $searchFormValues = []) {
+    $_POST = $formValues;
+    /* @var CRM_Core_Form $form */
+    $form = new $class();
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    switch ($class) {
+      case 'CRM_Event_Cart_Form_Checkout_Payment':
+      case 'CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices':
+        $form->controller = new CRM_Event_Cart_Controller_Checkout();
+        break;
+
+      default:
+        $form->controller = new CRM_Core_Controller();
+    }
+    if (!$pageName) {
+      $pageName = $form->getName();
+    }
+    $form->controller->setStateMachine(new CRM_Core_StateMachine($form->controller));
+    $_SESSION['_' . $form->controller->_name . '_container']['values'][$pageName] = $formValues;
+    if ($searchFormValues) {
+      $_SESSION['_' . $form->controller->_name . '_container']['values']['Search'] = $searchFormValues;
+    }
+    if (isset($formValues['_qf_button_name'])) {
+      $_SESSION['_' . $form->controller->_name . '_container']['_qf_button_name'] = $formValues['_qf_button_name'];
+    }
+    return $form;
+  }
+
 }

--- a/tests/phpunit/CRM/Iats/ContributionIATSTest.php
+++ b/tests/phpunit/CRM/Iats/ContributionIATSTest.php
@@ -64,14 +64,11 @@ class CRM_Iats_ContributioniATSTest extends BaseTestClass {
     $processor = $this->paymentProcessor->getPaymentProcessor();
     $this->paymentProcessorID = $processor['id'];
 
-    $form = new CRM_Contribute_Form_Contribution();
-    $form->_mode = 'Live';
-
     $contribution_params = array(
+      'soft_credit_contact_id' => array(),
       'total_amount' => 1.00,
       'financial_type_id' => 1,
-      'receive_date' => '08/03/2017',
-      'receive_date_time' => '11:59PM',
+      'receive_date' => date('Y-m-d H:i:s'),
       'contact_id' => $individual['id'],
       'payment_instrument_id' => 1,
       'contribution_status_id' => 1,
@@ -96,13 +93,16 @@ class CRM_Iats_ContributioniATSTest extends BaseTestClass {
       'hidden_AdditionalDetail' => 1,
       'hidden_Premium' => 1,
       'receipt_date' => '',
-      'receipt_date_time' => '',
+      'cancel_date' => '',
       'payment_processor_id' => $this->paymentProcessorID,
       'currency' => 'CAD',
       'source' => 'iATS CC TEST88',
     );
 
-    $form->testSubmit($contribution_params, CRM_Core_Action::ADD);
+    $form = $this->getFormObject('CRM_Contribute_Form_Contribution', $contribution_params);
+    $form->buildForm();
+    $form->_mode = 'Live';
+    $form->postProcess();
 
     $contribution = $this->callAPISuccessGetSingle('Contribution', array(
       'contact_id' => $individual['id'],
@@ -137,14 +137,11 @@ class CRM_Iats_ContributioniATSTest extends BaseTestClass {
     $processor = $this->paymentProcessor->getPaymentProcessor();
     $this->paymentProcessorID = $processor['id'];
 
-    $form = new CRM_Contribute_Form_Contribution();
-    $form->_mode = 'Live';
-
     $contribution_params = array(
+      'soft_credit_contact_id' => array(),
       'total_amount' => 2.00,
       'financial_type_id' => 1,
-      'receive_date' => '08/03/2017',
-      'receive_date_time' => '11:59PM',
+      'receive_date' => date('Y-m-d H:i:s'),
       'contact_id' => $individual['id'],
       'payment_instrument_id' => 1,
       'contribution_status_id' => 1,
@@ -170,13 +167,16 @@ class CRM_Iats_ContributioniATSTest extends BaseTestClass {
       'hidden_AdditionalDetail' => 1,
       'hidden_Premium' => 1,
       'receipt_date' => '',
-      'receipt_date_time' => '',
+      'cancel_date' => '',
       'payment_processor_id' => $this->paymentProcessorID,
       'currency' => 'CAD',
       'source' => 'iATS SWIPE TEST88',
     );
 
-    $form->testSubmit($contribution_params, CRM_Core_Action::ADD);
+    $form = $this->getFormObject('CRM_Contribute_Form_Contribution', $contribution_params);
+    $form->buildForm();
+    $form->_mode = 'Live';
+    $form->postProcess();
 
     $contribution = $this->callAPISuccessGetSingle('Contribution', array(
       'contact_id' => $individual['id'],


### PR DESCRIPTION
@KarinG as discussed

Other notes:
* An alternate to copying getFormObject from core would be to extend CiviUnitTestCase, but copying for now is least change.
* I think that as with almost all extensions the bootstrap.php file is incomplete and relies on a certain amount of external pre-setup to work. It may also account for the note you have in the test file about needing to require_once although that might be separate. But I haven't touched it here.