### PR TITLE
Filter out IPv6 addresses on First Pay Processors

### DIFF
--- a/CRM/Core/Payment/Faps.php
+++ b/CRM/Core/Payment/Faps.php
@@ -283,6 +283,10 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
     $isRecur = CRM_Utils_Array::value('is_recur', $params) && $params['contributionRecurID'];
     $usingCrypto = !empty($params['cryptogram']);
     $ipAddress = (function_exists('ip_address') ? ip_address() : $_SERVER['REMOTE_ADDR']);
+    // If we have an IPv6 Address ignore it.
+    if (!filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+      $ipAddress = '';
+    }
     $credentials = array(
       'merchantKey' => $this->_paymentProcessor['signature'],
       'processorId' => $this->_paymentProcessor['user_name']

--- a/CRM/Core/Payment/FapsACH.php
+++ b/CRM/Core/Payment/FapsACH.php
@@ -136,6 +136,10 @@ class CRM_Core_Payment_FapsACH extends CRM_Core_Payment_Faps {
     }
     $isRecur = CRM_Utils_Array::value('is_recur', $params) && $params['contributionRecurID'];
     $ipAddress = (function_exists('ip_address') ? ip_address() : $_SERVER['REMOTE_ADDR']);
+    // If we have an IPv6 Address ignore it.
+    if (!filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+      $ipAddress = '';
+    }
     $credentials = array(
       'merchantKey' => $this->_paymentProcessor['signature'],
       'processorId' => $this->_paymentProcessor['user_name']


### PR DESCRIPTION
We recently had a client who is using First Pay processor get an error message "Error: Client Ip address is not valid 2604:3d09:647b:bd50::cc8b". We also have a separate client who uses the legacy credit card method and looking in their journals ipv6 addresses appear to be accepted but for some reason not for first pay.