### PR TITLE
PHP 8.0 | Fix Undefined array key warnings during cron

### DIFF
--- a/api/v3/Job/Iatsrecurringcontributions.php
+++ b/api/v3/Job/Iatsrecurringcontributions.php
@@ -106,7 +106,7 @@ function civicrm_api3_job_Iatsrecurringcontributions($params) {
   $error_count  = 0;
   $output  = [];
   $settings = Civi::settings()->get('iats_settings');
-  $receipt_recurring = $settings['receipt_recurring'];
+  $receipt_recurring = $settings['receipt_recurring'] ?? null;
   $email_failure_report = empty($settings['email_recurring_failure_report']) ? '' : $settings['email_recurring_failure_report'];
   // By default, after 3 failures move the next scheduled contribution date forward.
   $failure_threshhold = empty($settings['recurring_failure_threshhold']) ? 3 : (int) $settings['recurring_failure_threshhold'];

--- a/api/v3/Job/Iatsverify.php
+++ b/api/v3/Job/Iatsverify.php
@@ -69,7 +69,7 @@ function _civicrm_api3_job_iatsverify_spec(&$spec) {
 function civicrm_api3_job_iatsverify($params) {
 
   $settings = Civi::settings()->get('iats_settings');
-  $receipt_recurring = $settings['receipt_recurring'];
+  $receipt_recurring = $settings['receipt_recurring'] ?? null;
   define('IATS_VERIFY_DAYS', 30);
   // I've added an extra 2 days when getting candidates from CiviCRM to be sure i've got them all.
   $verify_days = IATS_VERIFY_DAYS + 2;


### PR DESCRIPTION
If there are no recurring payments, cron returns these warnings:
Warning Undefined array key receipt_recurring Iatsverify.php:72
Warning Undefined array key receipt_recurring Iatsrecurringcontributions.php:109