### PR TITLE
#391 - php 8 error calling current() on object

### DIFF
--- a/CRM/Iats/iATSServiceRequest.php
+++ b/CRM/Iats/iATSServiceRequest.php
@@ -272,8 +272,8 @@ class CRM_Iats_iATSServiceRequest {
       case 'process':
         if (!empty($response->PROCESSRESULT)) {
           $processresult = $response->PROCESSRESULT;
-          $result['auth_result'] = trim(current($processresult->AUTHORIZATIONRESULT));
-          $result['remote_id'] = current($processresult->TRANSACTIONID);
+          $result['auth_result'] = trim(((array) $processresult->AUTHORIZATIONRESULT)[0] ?? '');
+          $result['remote_id'] = ((array) $processresult->TRANSACTIONID)[0] ?? '';
           // If we didn't get an approval response code...
           // Note: do not use SUCCESS property, which just means iATS said "hello".
           $result['status'] = (substr($result['auth_result'], 0, 2) == self::iATS_TXN_OK) ? 1 : 0;


### PR DESCRIPTION
See https://github.com/iATSPayments/com.iatspayments.civicrm/issues/391

Because civi is still supporting php 7.3, I needed to use function_exists(). That could go away with php 7.4. It's worth it though to be able to use a function called `get_mangled_object_vars`.