### PR TITLE
Renaming / reordering fields to match example CAD cheque #426

### DIFF
--- a/CRM/Core/Payment/iATSServiceACHEFT.php
+++ b/CRM/Core/Payment/iATSServiceACHEFT.php
@@ -179,7 +179,7 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
    * North American interbank system is consistent across US and Canada.
    */
   protected function buildForm_CAD(&$form) {
-    $form->addElement('text', 'cad_bank_number', ts('Bank N. (3 digits)'));
+    $form->addElement('text', 'cad_bank_number', ts('Bank No. (3 digits)'));
     $form->addRule('cad_bank_number', ts('%1 is a required field.', array(1 => ts('Bank No.'))), 'required');
     $form->addRule('cad_bank_number', ts('%1 must contain only digits.', array(1 => ts('Bank No.'))), 'numeric');
     $form->addRule('cad_bank_number', ts('%1 must be of length 3.', array(1 => ts('Bank No.'))), 'rangelength', array(3, 3));

--- a/CRM/Core/Payment/iATSServiceACHEFT.php
+++ b/CRM/Core/Payment/iATSServiceACHEFT.php
@@ -73,6 +73,10 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
 
   protected function getDirectDebitFormFields() {
     $fields = parent::getDirectDebitFormFields();
+    if ($fields[0] == 'account_holder') {
+      array_shift($fields);
+      $fields[] = 'account_holder';
+    }
     $fields[] = 'bank_account_type';
     // print_r($fields); die();
     return $fields;
@@ -95,6 +99,8 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
       'is_required' => TRUE,
       'attributes' => ['CHECKING' => 'Chequing', 'SAVING' => 'Savings'],
     ];
+    // Modify the label of Account Number to match our CAD Cheque
+    $metadata['bank_account_number']['title'] = ts('Account No.');
     return $metadata;
   }
 
@@ -173,14 +179,14 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
    * North American interbank system is consistent across US and Canada.
    */
   protected function buildForm_CAD(&$form) {
-    $form->addElement('text', 'cad_bank_number', ts('Bank Number (3 digits)'));
-    $form->addRule('cad_bank_number', ts('%1 is a required field.', array(1 => ts('Bank Number'))), 'required');
-    $form->addRule('cad_bank_number', ts('%1 must contain only digits.', array(1 => ts('Bank Number'))), 'numeric');
-    $form->addRule('cad_bank_number', ts('%1 must be of length 3.', array(1 => ts('Bank Number'))), 'rangelength', array(3, 3));
+    $form->addElement('text', 'cad_bank_number', ts('Bank N. (3 digits)'));
+    $form->addRule('cad_bank_number', ts('%1 is a required field.', array(1 => ts('Bank No.'))), 'required');
+    $form->addRule('cad_bank_number', ts('%1 must contain only digits.', array(1 => ts('Bank No.'))), 'numeric');
+    $form->addRule('cad_bank_number', ts('%1 must be of length 3.', array(1 => ts('Bank No.'))), 'rangelength', array(3, 3));
     $form->addElement('text', 'cad_transit_number', ts('Transit Number (5 digits)'));
-    $form->addRule('cad_transit_number', ts('%1 is a required field.', array(1 => ts('Transit Number'))), 'required');
-    $form->addRule('cad_transit_number', ts('%1 must contain only digits.', array(1 => ts('Transit Number'))), 'numeric');
-    $form->addRule('cad_transit_number', ts('%1 must be of length 5.', array(1 => ts('Transit Number'))), 'rangelength', array(5, 5));
+    $form->addRule('cad_transit_number', ts('%1 is a required field.', array(1 => ts('Transit No.'))), 'required');
+    $form->addRule('cad_transit_number', ts('%1 must contain only digits.', array(1 => ts('Transit No.'))), 'numeric');
+    $form->addRule('cad_transit_number', ts('%1 must be of length 5.', array(1 => ts('Transit No.'))), 'rangelength', array(5, 5));
     /* minor customization of labels + make them required  */
     /* $element = $form->getElement('account_holder');
     $element->setLabel(ts('Name of Account Holder'));

--- a/js/dd_cad.js
+++ b/js/dd_cad.js
@@ -22,7 +22,7 @@ CRM.$(function ($) {
   $('#cad_bank_number').blur(function(eventObj) {
     var myCount = onlyNumbers($(this));
     if ((myCount > 0) && (myCount != 3)) {
-      $(this).crmError(ts('Your Bank Number requires three digits, use a leading "0" if necessary')); 
+      $(this).crmError(ts('Your Bank No. requires three digits, use a leading "0" if necessary'));
     }
     switch($(this).val()) {
       case '001': $('#bank_name').val('Bank of Montreal'); break;
@@ -49,7 +49,7 @@ CRM.$(function ($) {
   $('#cad_transit_number').blur(function(eventObj) {
     var myCount = onlyNumbers($(this));
     if ((myCount > 0) && (myCount != 5)) {
-      $(this).crmError(ts('Your Bank Transit Number requires exactly five digits')); 
+      $(this).crmError(ts('Your Transit No. requires exactly five digits'));
     }
     iatsSetBankIdenficationNumber();
   });


### PR DESCRIPTION
Here are the changes that I indicated on the ticket #426 

The end result is like this, which I think is much more constant with the provided image. Let me know if you have any feedback and/or changes.

![Selection_021](https://github.com/iATSPayments/com.iatspayments.civicrm/assets/1126026/c57963e1-9523-420d-9421-2e84f81423bc)
