### PR TITLE
convert use of _paymentObject in buildForm hook

### DIFF
--- a/iats.php
+++ b/iats.php
@@ -257,9 +257,12 @@ function iats_civicrm_buildForm_CRM_Financial_Form_Payment(&$form) {
   }
   // If future public start dates are enabled on a recurring-enabled page ...
   // Uses javascript to hide/reset unless they have recurring contributions checked.
+  // 2023-11-08 updated how the payment processor object is found temporarily
+  //   update to use getter method in the future.
   $settings = Civi::settings()->get('iats_settings');
   if (!empty($settings['enable_public_future_recurring_start'])
-    && $form->getPaymentProcessorObject()->supports('FutureRecurStartDate')
+  //  && $form->getPaymentProcessorObject()->supports('FutureRecurStartDate') 
+    && $form->_paymentProcessor['object']->supports('FutureRecurStartDate')
   ) {
     $allow_days = empty($settings['days']) ? array('-1') : $settings['days'];
     $start_dates = CRM_Iats_Transaction::get_future_monthly_start_dates(time(), $allow_days);

--- a/iats.php
+++ b/iats.php
@@ -259,7 +259,7 @@ function iats_civicrm_buildForm_CRM_Financial_Form_Payment(&$form) {
   // Uses javascript to hide/reset unless they have recurring contributions checked.
   $settings = Civi::settings()->get('iats_settings');
   if (!empty($settings['enable_public_future_recurring_start'])
-    && $form->_paymentObject->supports('FutureRecurStartDate')
+    && $form->getPaymentProcessorObject()->supports('FutureRecurStartDate')
   ) {
     $allow_days = empty($settings['days']) ? array('-1') : $settings['days'];
     $start_dates = CRM_Iats_Transaction::get_future_monthly_start_dates(time(), $allow_days);


### PR DESCRIPTION
As per issue https://github.com/iATSPayments/com.iatspayments.civicrm/issues/438

Since this hook gets called from some other hooks, we need to make sure those contexts also have the getPaymentProcessorObject() method available.