### PR TITLE
Handle for possibility of blank source field in contribution originally

### DIFF
--- a/CRM/Iats/Transaction.php
+++ b/CRM/Iats/Transaction.php
@@ -90,6 +90,7 @@ class CRM_Iats_Transaction {
     $auth_code = $payment_result['auth_code'];
     $auth_response = empty($payment_result['auth_response']) ? '' : $payment_result['auth_response'];
     $trxn_id = empty($payment_result['trxn_id']) ? '' : $payment_result['trxn_id'];
+    $contribution['source'] = $contribution['source'] ?? '';
     // Handle any case of a failure of some kind, either the card failed, or the system failed.
     if (!$success) {
       $error_message = $payment_result['message'];

--- a/api/v3/Job/Iatsverify.php
+++ b/api/v3/Job/Iatsverify.php
@@ -183,7 +183,7 @@ function civicrm_api3_job_iatsverify($params) {
             // Restore source field and trxn_id that completetransaction overwrites
             civicrm_api3('contribution', 'create', array(
               'id' => $contribution['id'],
-              'source' => ($contribution['contribution_source'] ?? $contribution['source']),
+              'source' => ($contribution['contribution_source'] ?? $contribution['source'] ?? ''),
               'trxn_id' => $trxn_id,
             ));
             break;


### PR DESCRIPTION
On one of our clients sites I was getting a notice error about undefined index source in L186 of the iatsVerify job.  I also noticed that we assume in the Transaction job that the key source is a string along the way. This just works to deal with the possibility that some how a contribution has a null value in the database for the source. 

ping @adixon @KarinG 