### PR TITLE
avoid undefined array key 'price_field_value_id' errors in php 8

### DIFF
--- a/CRM/Iats/Transaction.php
+++ b/CRM/Iats/Transaction.php
@@ -38,7 +38,9 @@ class CRM_Iats_Transaction {
         foreach ($result['values'] as $initial_line_item) {
           $line_item = array();
           foreach (array('price_field_id', 'qty', 'line_total', 'unit_price', 'label', 'price_field_value_id', 'financial_type_id') as $key) {
-            $line_item[$key] = $initial_line_item[$key];
+            if (array_key_exists($key, $initial_line_item)) {
+              $line_item[$key] = $initial_line_item[$key];
+            }
           }
           $template['line_items'][] = $line_item;
         }


### PR DESCRIPTION
I'm not sure if skipping a missing key is best or whether it should be kept and set to ''?

Without this patch I get:

> PHP Warning] Undefined array key "price_field_value_id" at /var/www/powerbase/sites/all/extensions/iats/CRM/Iats/Transaction.php:41