### PR TITLE
Update Exception references in Fapsquery

### DIFF
--- a/api/v3/Job/Fapsquery.php
+++ b/api/v3/Job/Fapsquery.php
@@ -30,7 +30,7 @@ function _civicrm_api3_job_fapsquery_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_job_fapsquery($params) {
 
@@ -44,8 +44,8 @@ function civicrm_api3_job_fapsquery($params) {
       'is_test' => 0,
     ));
   }
-  catch (CiviCRM_API3_Exception $e) {
-    throw new API_Exception('Unexpected error getting payment processors: ' . $e->getMessage()); //  . "\n" . $e->getTraceAsString());
+  catch (CRM_Core_Exception $e) {
+    throw new CRM_Core_Exception('Unexpected error getting payment processors: ' . $e->getMessage()); //  . "\n" . $e->getTraceAsString());
   }
   if (empty($result['values'])) {
     return;
@@ -124,7 +124,7 @@ function civicrm_api3_job_fapsquery($params) {
           civicrm_api3('FapsTransaction', 'journal', $transaction);
           $processed[$user_name][$type]++;
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           $error_log[] = $e->getMessage();
         }
       }


### PR DESCRIPTION
Since 5.52 the classes `API_Exception` and `CiviCRM_API3_Exception` no longer exist.

They still work because they are aliased to `CRM_Core_Exception` - but using them is deprecated and eventually won't work.

Note I have only tackled one file here - there are others affected but I've just done similar PRs on a bunch of other extensions & this is where I hit a wall

@ufundo @artfulrobot - pinging you both cos there are some  instances of `API_exception` in the standalone code - which is fairly new - so just raising awareness.... 