### PR TITLE
Decode special characters then replace or strip to avoid Paysafe REJ: 23

### DIFF
--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -427,8 +427,7 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
 
     foreach ($convert as $r => $p) {
       if (isset($params[$p])) {
-        $params[$p] = str_replace(str_split(".',`;&"), '', $params[$p]);
-        $request[$r] = htmlspecialchars($params[$p]);
+        $request[$r] = str_replace(str_split(";"), '', $params[$p]);
       }
     }
     

--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -427,31 +427,11 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
 
     foreach ($convert as $r => $p) {
       if (isset($params[$p])) {
+        $params[$p] = str_replace(str_split(".',`;&"), '', $params[$p]);
         $request[$r] = htmlspecialchars($params[$p]);
       }
     }
-    // The "&" character is badly handled by the processor,
-    // so we sanitize it to "and"
-    // but before we do that we first we need to html_entity_decode as CiviCRM
-    // is changing ' to &#039; now (obversed in names O&#039;Reilly; in a City: St. John's and in Street Address)
-    $request['firstName'] = html_entity_decode($request['firstName']);
-    $request['lastName'] = html_entity_decode($request['lastName']);
-    $request['city'] = html_entity_decode($request['city']);
-    $request['address'] = html_entity_decode($request['address']);
-
-    // replacing & with and
-    // replacing ' and . with nothing
-    $request['firstName'] = str_replace('&', 'and', $request['firstName']);
-    $request['lastName'] = str_replace('&', 'and', $request['lastName']);
-    $request['firstName'] = str_replace("'", "", $request['firstName']);
-    $request['lastName'] = str_replace("'", "", $request['lastName']);
-    $request['city'] = str_replace("'", "", $request['city']);
-    $request['address'] = str_replace("'", "", $request['address']);
-    $request['firstName'] = str_replace(".", "", $request['firstName']);
-    $request['lastName'] = str_replace(".", "", $request['lastName']);
-    $request['city'] = str_replace(".", "", $request['city']);
-    $request['address'] = str_replace(".", "", $request['address']);
-
+    
     $request['creditCardExpiry'] = sprintf('%02d/%02d', intval($params['month']), (intval($params['year']) % 100));
     $request['total'] = sprintf('%01.2f', CRM_Utils_Rule::cleanMoney($params['amount']));
     // Place for ugly hacks.

--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -432,8 +432,26 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
     }
     // The "&" character is badly handled by the processor,
     // so we sanitize it to "and"
+    // but before we do that we first we need to html_entity_decode as CiviCRM
+    // is changing ' to &#039; now (obversed in names O&#039;Reilly; in a City: St. John's and in Street Address)
+    $request['firstName'] = html_entity_decode($request['firstName']);
+    $request['lastName'] = html_entity_decode($request['lastName']);
+    $request['city'] = html_entity_decode($request['city']);
+    $request['address'] = html_entity_decode($request['address']);
+
+    // replacing & with and
+    // replacing ' and . with nothing
     $request['firstName'] = str_replace('&', 'and', $request['firstName']);
     $request['lastName'] = str_replace('&', 'and', $request['lastName']);
+    $request['firstName'] = str_replace("'", "", $request['firstName']);
+    $request['lastName'] = str_replace("'", "", $request['lastName']);
+    $request['city'] = str_replace("'", "", $request['city']);
+    $request['address'] = str_replace("'", "", $request['address']);
+    $request['firstName'] = str_replace(".", "", $request['firstName']);
+    $request['lastName'] = str_replace(".", "", $request['lastName']);
+    $request['city'] = str_replace(".", "", $request['city']);
+    $request['address'] = str_replace(".", "", $request['address']);
+
     $request['creditCardExpiry'] = sprintf('%02d/%02d', intval($params['month']), (intval($params['year']) % 100));
     $request['total'] = sprintf('%01.2f', CRM_Utils_Rule::cleanMoney($params['amount']));
     // Place for ugly hacks.


### PR DESCRIPTION
**Before:**
G'erritsen becomes -> Gand#039;erritsen

**After:**
' is removed. Along with .
Also removed from Street Address and City [based on real life failures].

**Recent real life failures:**
A Member trying to pay his dues 8x over 3 days with two different credit cards:
<img width="216" alt="image" src="https://github.com/user-attachments/assets/22668f27-e660-4085-9b6a-1294dcc07f8b">

**Note:**
When testing this TEST88 and TE4188 happily accept / complete transactions with namee like Gand#039;erritsen - one of the reasons this has gone undetected.

Screenshot showing before this PR (first row) and after this PR (second row).
<img width="1162" alt="image" src="https://github.com/user-attachments/assets/f86700e7-4c45-4d43-a317-f9b3591c4077">
