### PR TITLE
composer: Add civicrm-ext type and package name in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
-    "name": "iats-payments/civicrm",
+    "name": "iatspayments/com.iatspayments.civicrm",
     "description": "CiviCRM extension for iATS Payments",
+    "type": "civicrm-ext",
     "license": "AGPL-3.0"
 }


### PR DESCRIPTION
Implements all changes from #472

fixes: #472