### PR TITLE
getCurrentRevisions function in upgrader causes crash in 1.10

### DIFF
--- a/CRM/Iats/Upgrader.php
+++ b/CRM/Iats/Upgrader.php
@@ -8,19 +8,6 @@ class CRM_Iats_Upgrader extends CRM_Extension_Upgrader_Base {
   // By convention, functions that look like "function upgrade_NNNN()" are
   // upgrade tasks. They are executed in order (like Drupal's hook_update_N).
 
-  public function getCurrentRevision() {
-    // reset the saved extension version as well
-    try {
-      $xmlfile = CRM_Core_Resources::singleton()->getPath('com.iatspayments.civicrm','info.xml');
-      $myxml = simplexml_load_file($xmlfile);
-      $version = (string) $myxml->version;
-      Civi::settings()->set('iats_extension_version', $version);
-    }
-    catch (Exception $e) {
-      // ignore
-    }
-    return parent::getCurrentRevision();
-  }
   /**
    * Standard: run an install sql script
    */


### PR DESCRIPTION
e.g. just download the latest master and visit the extensions page.

The civix [upgrade](https://github.com/iATSPayments/com.iatspayments.civicrm/commit/cb769ae78c69aa03e15171f2151d1407d9e7c4bf#diff-cebfd330bf19add02887c89fee086ba182534f40fbb1fdd13aacbb6fa73b67f6) commit added the civimix-schema thing which has another thing called the automaticupgrader. It doesn't like the getCurrentRevisions function. That function seems like something left over from olden times [added](https://github.com/iATSPayments/com.iatspayments.civicrm/commit/d4f26bc588ced5405d4b6ac4db5a580162926e07) to solve some kind of issue back then? I removed it and besides solving the crash it still worked fine to recognize a new upgrade step and run it. The iATSAdmin page still shows the version.

Sidenote: The naming convention for upgrade task functions here will break down soon. If there actually was a 1.10 upgrade step, note that it thinks 1_10 is less than 1_9. Will need to think about that someday.