### PR TITLE
Fix title of iats_receipt_recurring caused by copy and paste error

### DIFF
--- a/settings/iats.setting.php
+++ b/settings/iats.setting.php
@@ -38,7 +38,7 @@ return [
     'type' => 'String',
     'default' => '',
     'html_type' => 'select',
-    'title' => E::ts('Email Recurring Contribution failure reports to this Email address'),
+    'title' => E::ts('Email receipt for a Contribution in a Recurring Series'),
     'is_domain' => 1,
     'is_contact' => 0,
     'settings_pages' => ['iats' => ['weight' => 40]],


### PR DESCRIPTION
This fixes a copy and paste error on my part and resets the title back to the original title as per here https://github.com/iATSPayments/com.iatspayments.civicrm/commit/f7b8f48ce10846684d8a77c5477e7d16d01e6b73#diff-82aa0e15aba1541c2e8165f0f766f383d16c2ee0d4a2013b5bdfdf27439eb64eL36

@adixon 