### PR TITLE
Fix bcc of recurring failure notices

### DIFF
--- a/api/v3/Job/Iatsrecurringcontributions.php
+++ b/api/v3/Job/Iatsrecurringcontributions.php
@@ -143,7 +143,6 @@ function civicrm_api3_job_Iatsrecurringcontributions($params) {
     $output[] = $failure_report_text;
   }
   else {
-    CRM_Core_Error::debug_var('recurring Contributions', $recurringContributions['values']);
     foreach($recurringContributions['values'] as $recurringContribution) {
       // Strategy: create the contribution record with status = 2 (= pending), try the payment, and update the status to 1 if successful
       //           also, advance the next scheduled payment before the payment attempt and pull it back if we know it fails.
@@ -373,11 +372,10 @@ function civicrm_api3_job_Iatsrecurringcontributions($params) {
       'from' => $emailFromName . ' <' . $emailFromEmail . '> ',
       'toName' => empty($emailFromName) ? ts('System Administrator') : $emailFromName,
       'toEmail' => $email_failure_report,
-      'bcc' =>  !empty($bcc_email_failure_report) ?  $bcc_email_failure_report : '',
+      'bcc' =>  !empty($settings['bcc_email_recurring_failure_report']) ? $settings['bcc_email_recurring_failure_report'] : '',
       'subject' => ts('iATS Recurring Payment job failure report: ' . date('c')),
       'text' => $failure_report_text,
     );
-    // print_r($mailparams);
     CRM_Utils_Mail::send($mailparams);
   }
 


### PR DESCRIPTION
I don't think it's ever worked. Either that or it was intended as an EXTREME BCC, where not only do you not see the recipient but the recipient can't even see the email contents (grin).

It references a nonexistent variable.
