### PR TITLE
Add in Integration with Firewall extension

### DIFF
--- a/CRM/Core/Payment/Faps.php
+++ b/CRM/Core/Payment/Faps.php
@@ -550,6 +550,9 @@ class CRM_Core_Payment_Faps extends CRM_Core_Payment {
    *
    */
   public function &error($error = NULL) {
+    if (CRM_Iats_Utils::isFirewallEnabled()) {
+      \Civi\Firewall\Event\DeclinedCardEvent::trigger(\Civi\Firewall\Firewall::getIPAddress(), 'Iats Faps error');
+    }
     $error_code = 'process_1stpay';
     if (is_object($error)) {
       throw new PaymentProcessorException(ts('Error %1', [1 => $error->getMessage()]), $error_code);

--- a/CRM/Core/Payment/iATSService.php
+++ b/CRM/Core/Payment/iATSService.php
@@ -363,6 +363,14 @@ class CRM_Core_Payment_iATSService extends CRM_Core_Payment {
    *
    */
   public function &error($error = NULL) {
+    if (CRM_Iats_Utils::isFirewallEnabled()) {
+      if (is_string($error) && (str_contains('tumbling', $error) || str_contains('stolen', $error))) {
+        \Civi\Firewall\Event\FraudEvent::trigger(\Civi\Firewall\Firewall::getIPAddress(), 'Iats Service error');
+      }
+      else {
+        \Civi\Firewall\Event\DeclinedCardEvent::trigger(\Civi\Firewall\Firewall::getIPAddress(), 'Iats Service error');
+      }
+    }
     if (is_object($error)) {
       throw new PaymentProcessorException(ts('Error %1', [1 => $error->getMessage()]));
     }

--- a/CRM/Core/Payment/iATSServiceACHEFT.php
+++ b/CRM/Core/Payment/iATSServiceACHEFT.php
@@ -387,6 +387,14 @@ class CRM_Core_Payment_iATSServiceACHEFT extends CRM_Core_Payment_iATSService {
    *
    */
   public function &error($error = NULL) {
+    if (CRM_Iats_Utils::isFirewallEnabled()) {
+      if (is_string($error) && (str_contains('tumbling', $error) || str_contains('stolen', $error))) {
+        \Civi\Firewall\Event\FraudEvent::trigger(\Civi\Firewall\Firewall::getIPAddress(), 'Iats Service ACHEFT error');
+      }
+      else {
+        \Civi\Firewall\Event\DeclinedCardEvent::trigger(\Civi\Firewall\Firewall::getIPAddress(), 'Iats Service ACHEFT error');
+      }
+    }
     if (is_object($error)) {
       throw new PaymentProcessorException(ts('Error %1', [1 => $error->getMessage()]));
     }

--- a/CRM/Iats/Utils.php
+++ b/CRM/Iats/Utils.php
@@ -55,4 +55,14 @@ class CRM_Iats_Utils {
     return $days;
   }
 
+  public static function isFirewallEnabled(): bool {
+    $extensionCheck = \Civi\Api4\Extension::get(FALSE)
+      ->addWhere('key', '=', 'firewall')
+      ->execute();
+    if (count($extensionCheck) == 0 || $extensionCheck[0]['status'] !== 'installed') {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
 }


### PR DESCRIPTION
This adds a condiditional integration with the [Firewall](https://civicrm.org/extensions/firewall) to trigger specific events within that firewall when Iats issues a decline