### PR TITLE
Replace removed addDateTime

### DIFF
--- a/iats.php
+++ b/iats.php
@@ -689,7 +689,7 @@ function iats_civicrm_buildForm_CRM_Contribute_Form_UpdateSubscription(&$form) {
         $form->addElement('select', $fid, ts($label), $receiptStatus);
         break;
       default:
-        $form->addDateTime($fid, ts($label));
+        $form->add('datepicker', $fid, ts($label));
         break;
     }
   }


### PR DESCRIPTION
addDateTime stopped working in 6.5, resulting in an error when trying to edit a recurring contribution, so editing was no longer possible.